### PR TITLE
Add generic AbilityOf lookup and friendly ability errors

### DIFF
--- a/serenity/core/ability.go
+++ b/serenity/core/ability.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/nchursin/serenity-go/serenity/abilities"
+)
+
+func abilityTypeName(t reflect.Type) string {
+	if t == nil {
+		return "<nil>"
+	}
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t.String()
+}
+
+func abilityTypeNameFor[T abilities.Ability]() string {
+	return abilityTypeName(reflect.TypeOf((*T)(nil)).Elem())
+}
+
+// AbilityName returns the readable name of the provided ability instance.
+func AbilityName(ability abilities.Ability) string {
+	return abilityTypeName(reflect.TypeOf(ability))
+}
+
+// AbilityOf returns the first ability of type T held by the actor or an error
+// with a human-friendly message when missing.
+func AbilityOf[T abilities.Ability](actor Actor) (T, error) {
+	var zero T
+	abName := abilityTypeNameFor[T]()
+
+	if actor == nil {
+		return zero, fmt.Errorf("actor is nil; cannot get %s ability", abName)
+	}
+
+	ab, err := actor.AbilityTo(zero)
+	if err != nil {
+		return zero, fmt.Errorf("actor '%s' can't %s. Did you give them the ability?", actor.Name(), abName)
+	}
+
+	typed, ok := ab.(T)
+	if !ok {
+		return zero, fmt.Errorf("actor '%s' returned ability of wrong type (got %s, want %s)", actor.Name(), AbilityName(ab), abName)
+	}
+
+	return typed, nil
+}

--- a/serenity/core/ability_test.go
+++ b/serenity/core/ability_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nchursin/serenity-go/serenity/abilities"
+)
+
+type testAbility struct{ id string }
+type otherAbility struct{}
+
+type stubActor struct {
+	name          string
+	abilityToResp abilities.Ability
+	abilityErr    error
+}
+
+func (s *stubActor) Context() context.Context { return context.Background() }
+func (s *stubActor) Name() string             { return s.name }
+func (s *stubActor) WhoCan(_ ...abilities.Ability) Actor {
+	return s
+}
+func (s *stubActor) AbilityTo(_ abilities.Ability) (abilities.Ability, error) {
+	if s.abilityErr != nil {
+		return nil, s.abilityErr
+	}
+	return s.abilityToResp, nil
+}
+func (s *stubActor) AttemptsTo(_ ...Activity)              {}
+func (s *stubActor) AnswersTo(_ Question[any]) (any, bool) { return nil, false }
+
+func TestAbilityNameStripsPointer(t *testing.T) {
+	ab := &testAbility{}
+	if got := AbilityName(ab); got != "core.testAbility" {
+		t.Fatalf("expected core.testAbility, got %s", got)
+	}
+}
+
+func TestAbilityNameHandlesNil(t *testing.T) {
+	if got := AbilityName(nil); got != "<nil>" {
+		t.Fatalf("expected <nil>, got %s", got)
+	}
+}
+
+func TestAbilityOfSuccess(t *testing.T) {
+	wanted := &testAbility{id: "ok"}
+	actor := &stubActor{name: "A", abilityToResp: wanted}
+
+	got, err := AbilityOf[*testAbility](actor)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != wanted {
+		t.Fatalf("expected %#v, got %#v", wanted, got)
+	}
+}
+
+func TestAbilityOfNilActor(t *testing.T) {
+	_, err := AbilityOf[*testAbility](nil)
+	expected := "actor is nil; cannot get core.testAbility ability"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected %q, got %v", expected, err)
+	}
+}
+
+func TestAbilityOfPropagatesFriendlyMessageOnMissing(t *testing.T) {
+	actor := &stubActor{name: "A", abilityErr: errors.New("missing")}
+	_, err := AbilityOf[*testAbility](actor)
+	expected := "actor 'A' can't core.testAbility. Did you give them the ability?"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected %q, got %v", expected, err)
+	}
+}
+
+func TestAbilityOfDetectsTypeMismatch(t *testing.T) {
+	actor := &stubActor{name: "A", abilityToResp: &otherAbility{}}
+	_, err := AbilityOf[*testAbility](actor)
+	expected := "actor 'A' returned ability of wrong type (got core.otherAbility, want core.testAbility)"
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected %q, got %v", expected, err)
+	}
+}

--- a/serenity/testing/actor.go
+++ b/serenity/testing/actor.go
@@ -73,7 +73,8 @@ func (ta *testActor) AbilityTo(abilityType abilities.Ability) (abilities.Ability
 		}
 	}
 
-	return nil, fmt.Errorf("actor '%s' does not have the required ability", ta.name)
+	abName := core.AbilityName(abilityType)
+	return nil, fmt.Errorf("actor '%s' can't %s. Did you give them the ability?", ta.name, abName)
 }
 
 // AttemptsTo executes activities and automatically handles any errors through TestContext.

--- a/serenity/testing/actor_test.go
+++ b/serenity/testing/actor_test.go
@@ -6,12 +6,15 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	"github.com/nchursin/serenity-go/serenity/abilities"
 	"github.com/nchursin/serenity-go/serenity/core"
 	coreMocks "github.com/nchursin/serenity-go/serenity/core/testing/mocks"
 	"github.com/nchursin/serenity-go/serenity/reporting"
 	reportingMocks "github.com/nchursin/serenity-go/serenity/reporting/mocks"
 	testingMocks "github.com/nchursin/serenity-go/serenity/testing/mocks"
 )
+
+type dummyAbility struct{ id string }
 
 func TestTestActorAttemptsToWithReporting(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -48,4 +51,89 @@ func TestTestActorAttemptsToWithReporting(t *testing.T) {
 
 	// Execute activity
 	actor.AttemptsTo(mockActivity)
+}
+
+func TestAbilityToReturnsFriendlyError(t *testing.T) {
+	actor := &testActor{
+		name:      "TestActor",
+		ctx:       context.Background(),
+		abilities: []abilities.Ability{},
+	}
+
+	ability, err := actor.AbilityTo(&dummyAbility{})
+	if err == nil {
+		t.Fatalf("expected error, got nil and ability %v", ability)
+	}
+
+	expected := "actor 'TestActor' can't testing.dummyAbility. Did you give them the ability?"
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestAbilityOfReturnsConcreteAbility(t *testing.T) {
+	first := &dummyAbility{id: "first"}
+	actor := &testActor{
+		name:      "TestActor",
+		ctx:       context.Background(),
+		abilities: []abilities.Ability{first},
+	}
+
+	ability, err := core.AbilityOf[*dummyAbility](actor)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if ability != first {
+		t.Fatalf("expected first ability, got %+v", ability)
+	}
+}
+
+func TestAbilityOfReturnsFriendlyErrorWhenMissing(t *testing.T) {
+	actor := &testActor{
+		name:      "TestActor",
+		ctx:       context.Background(),
+		abilities: []abilities.Ability{},
+	}
+
+	ability, err := core.AbilityOf[*dummyAbility](actor)
+	if err == nil {
+		t.Fatalf("expected error, got ability %+v", ability)
+	}
+
+	expected := "actor 'TestActor' can't testing.dummyAbility. Did you give them the ability?"
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestAbilityOfReturnsFirstMatchingAbility(t *testing.T) {
+	first := &dummyAbility{id: "first"}
+	second := &dummyAbility{id: "second"}
+	actor := &testActor{
+		name:      "TestActor",
+		ctx:       context.Background(),
+		abilities: []abilities.Ability{first, second},
+	}
+
+	ability, err := core.AbilityOf[*dummyAbility](actor)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if ability != first {
+		t.Fatalf("expected first ability, got %+v", ability)
+	}
+}
+
+func TestAbilityOfHandlesNilActor(t *testing.T) {
+	ability, err := core.AbilityOf[*dummyAbility](nil)
+	if err == nil {
+		t.Fatalf("expected error, got ability %+v", ability)
+	}
+
+	expected := "actor is nil; cannot get testing.dummyAbility ability"
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
 }


### PR DESCRIPTION
## Summary
- add generic core.AbilityOf to return typed abilities
- align ability error messages for AbilityTo/AbilityOf with friendly phrasing
- cover behavior with tests including nil actor and multiple abilities

## Testing
- go test ./...