### PR TITLE
Add interface support to AbilityOf

### DIFF
--- a/serenity/core/ability.go
+++ b/serenity/core/ability.go
@@ -31,12 +31,22 @@ func AbilityName(ability abilities.Ability) string {
 func AbilityOf[T abilities.Ability](actor Actor) (T, error) {
 	var zero T
 	abName := abilityTypeNameFor[T]()
+	targetType := reflect.TypeOf((*T)(nil)).Elem()
+
+	abilityToken := reflect.New(targetType)
+
+	var requested abilities.Ability
+	if targetType.Kind() == reflect.Interface {
+		requested = abilityToken.Interface().(abilities.Ability)
+	} else {
+		requested = abilityToken.Elem().Interface().(abilities.Ability)
+	}
 
 	if actor == nil {
 		return zero, fmt.Errorf("actor is nil; cannot get %s ability", abName)
 	}
 
-	ab, err := actor.AbilityTo(zero)
+	ab, err := actor.AbilityTo(requested)
 	if err != nil {
 		return zero, fmt.Errorf("actor '%s' can't %s. Did you give them the ability?", actor.Name(), abName)
 	}

--- a/serenity/testing/actor_test.go
+++ b/serenity/testing/actor_test.go
@@ -16,6 +16,15 @@ import (
 
 type dummyAbility struct{ id string }
 
+type ifaceAbility interface {
+	abilities.Ability
+	Foo() string
+}
+
+type ifaceImpl struct{ id string }
+
+func (i *ifaceImpl) Foo() string { return i.id }
+
 func TestTestActorAttemptsToWithReporting(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -135,5 +144,42 @@ func TestAbilityOfHandlesNilActor(t *testing.T) {
 	expected := "actor is nil; cannot get testing.dummyAbility ability"
 	if err.Error() != expected {
 		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestAbilityOfSupportsInterfaceAbility(t *testing.T) {
+	impl := &ifaceImpl{id: "ok"}
+	actor := &testActor{
+		name:      "TestActor",
+		ctx:       context.Background(),
+		abilities: []abilities.Ability{impl},
+	}
+
+	ability, err := core.AbilityOf[ifaceAbility](actor)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if ability.Foo() != "ok" {
+		t.Fatalf("expected Foo to return ok, got %s", ability.Foo())
+	}
+}
+
+func TestAbilityOfReturnsFirstMatchingInterfaceAbility(t *testing.T) {
+	first := &ifaceImpl{id: "first"}
+	second := &ifaceImpl{id: "second"}
+	actor := &testActor{
+		name:      "TestActor",
+		ctx:       context.Background(),
+		abilities: []abilities.Ability{first, second},
+	}
+
+	ability, err := core.AbilityOf[ifaceAbility](actor)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if ability != first {
+		t.Fatalf("expected first interface ability, got %+v", ability)
 	}
 }

--- a/serenity/testing/helpers.go
+++ b/serenity/testing/helpers.go
@@ -7,27 +7,44 @@
 package testing
 
 import (
-	"fmt"
+	"reflect"
 
 	"github.com/nchursin/serenity-go/serenity/abilities"
 )
 
-// abilityMatchesType checks if two abilities are of the same type.
-// This helper function is used internally to match ability types when
-// retrieving specific abilities from an actor's ability collection.
-//
-// Parameters:
-//
-//	ability - The ability instance to check
-//	abilityType - The type reference ability to match against
-//
-// Returns:
-//
-//	true if the abilities are of the same concrete type, false otherwise
-//
-// This function uses type string comparison to determine type equality,
-// which is sufficient for the current ability system where each ability
-// type has a unique implementation.
-func abilityMatchesType(ability, abilityType abilities.Ability) bool {
-	return fmt.Sprintf("%T", ability) == fmt.Sprintf("%T", abilityType)
+// abilityMatchesType checks if the provided ability is assignable to or implements
+// the target ability type (interface or concrete) based on runtime types.
+func abilityMatchesType(ability abilities.Ability, abilityType abilities.Ability) bool {
+	if ability == nil || abilityType == nil {
+		return false
+	}
+
+	targetType := reflect.TypeOf(abilityType)
+	abType := reflect.TypeOf(ability)
+
+	if abType.AssignableTo(targetType) || (targetType.Kind() == reflect.Interface && abType.Implements(targetType)) {
+		return true
+	}
+
+	if abType.Kind() == reflect.Pointer {
+		abElem := abType.Elem()
+		if abElem.AssignableTo(targetType) || (targetType.Kind() == reflect.Interface && abElem.Implements(targetType)) {
+			return true
+		}
+	}
+
+	if targetType.Kind() == reflect.Pointer {
+		targetElem := targetType.Elem()
+		if abType.AssignableTo(targetElem) || (targetElem.Kind() == reflect.Interface && abType.Implements(targetElem)) {
+			return true
+		}
+		if abType.Kind() == reflect.Pointer {
+			abElem := abType.Elem()
+			if abElem.AssignableTo(targetElem) || (targetElem.Kind() == reflect.Interface && abElem.Implements(targetElem)) {
+				return true
+			}
+		}
+	}
+
+	return abType.String() == targetType.String()
 }

--- a/serenity/testing/helpers_test.go
+++ b/serenity/testing/helpers_test.go
@@ -1,0 +1,72 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/nchursin/serenity-go/serenity/abilities"
+)
+
+type helperIfaceAbility interface {
+	abilities.Ability
+	Foo() string
+}
+
+type helperIfaceImpl struct{ id string }
+
+func (i helperIfaceImpl) Foo() string { return i.id }
+
+type helperOtherAbility struct{ abilities.Ability }
+
+func TestAbilityMatchesTypeNilInputs(t *testing.T) {
+	if abilityMatchesType(nil, nil) {
+		t.Fatalf("expected false for nil inputs")
+	}
+
+	if abilityMatchesType(&helperIfaceImpl{id: "x"}, nil) {
+		t.Fatalf("expected false for nil target type")
+	}
+
+	if abilityMatchesType(nil, (*helperIfaceAbility)(nil)) {
+		t.Fatalf("expected false for nil ability")
+	}
+}
+
+func TestAbilityMatchesTypeConcreteToConcrete(t *testing.T) {
+	ab := &helperOtherAbility{}
+	target := &helperOtherAbility{}
+	if !abilityMatchesType(ab, target) {
+		t.Fatalf("expected concrete types to match")
+	}
+}
+
+func TestAbilityMatchesTypePointerImplementsInterface(t *testing.T) {
+	ab := &helperIfaceImpl{id: "ok"}
+	var target helperIfaceAbility
+	if !abilityMatchesType(ab, &target) {
+		t.Fatalf("expected pointer receiver to satisfy interface")
+	}
+}
+
+func TestAbilityMatchesTypeValueImplementsInterface(t *testing.T) {
+	ab := helperIfaceImpl{id: "ok"}
+	var target helperIfaceAbility
+	if !abilityMatchesType(ab, &target) {
+		t.Fatalf("expected value receiver to satisfy interface")
+	}
+}
+
+func TestAbilityMatchesTypePointerInterfaceTarget(t *testing.T) {
+	ab := &helperIfaceImpl{id: "ok"}
+	var target helperIfaceAbility
+	if !abilityMatchesType(ab, &target) {
+		t.Fatalf("expected pointer interface target to match")
+	}
+}
+
+func TestAbilityMatchesTypeNonMatching(t *testing.T) {
+	ab := &helperIfaceImpl{id: "ok"}
+	nonMatching := &helperOtherAbility{}
+	if abilityMatchesType(ab, nonMatching) {
+		t.Fatalf("expected non-matching types to be false")
+	}
+}


### PR DESCRIPTION
## Summary
- allow AbilityOf to resolve abilities by interface types via reflect-aware lookup
- update test actor matching to detect interface implementations and keep order
- add coverage for interface abilities and first-match behavior

## Test Plan
- go test ./...