### PR TITLE
feat(reporting): add native Allure reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,39 @@ test := serenity.NewSerenityTestWithReporter(t, reporter)
 
 For detailed documentation on console reporting, see [docs/reporting.md](docs/reporting.md).
 
+## Allure Reporting
+
+Serenity-Go includes a native Allure reporter that writes Allure 2 result files, step data, and attachments.
+
+```go
+import (
+    "context"
+
+    "github.com/nchursin/serenity-go/serenity/reporting/allure_reporter"
+    serenity "github.com/nchursin/serenity-go/serenity/testing"
+)
+
+func TestWithAllure(t *testing.T) {
+    reporter := allure_reporter.NewAllureReporterWithDir("allure-results")
+
+    test := serenity.NewSerenityTest(t, serenity.Scene{
+        Context:  context.Background(),
+        Reporter: reporter,
+    })
+
+    actor := test.ActorCalled("Tester")
+    actor.AttemptsTo(
+        // your activities
+    )
+}
+```
+
+Generate a local HTML report after test run:
+
+```bash
+allure serve allure-results
+```
+
 ## Working Examples
 
 The `examples/` directory contains working examples with real APIs:

--- a/docs/reporting.md
+++ b/docs/reporting.md
@@ -56,6 +56,43 @@ func TestCustomReporting(t *testing.T) {
 
 ## Custom Reporter Configuration
 
+## Allure Reporter
+
+Для CI и rich-отчетов можно использовать нативный Allure-репортер.
+
+```go
+import (
+    "context"
+
+    "github.com/nchursin/serenity-go/serenity/reporting/allure_reporter"
+    serenity "github.com/nchursin/serenity-go/serenity/testing"
+)
+
+func TestWithAllure(t *testing.T) {
+    reporter := allure_reporter.NewAllureReporterWithDir("allure-results")
+
+    test := serenity.NewSerenityTest(t, serenity.Scene{
+        Context:  context.Background(),
+        Reporter: reporter,
+    })
+
+    actor := test.ActorCalled("Tester")
+    actor.AttemptsTo(
+        // ... активности
+    )
+}
+```
+
+Репортер сохраняет:
+- `*-result.json` с test status и шагами
+- файлы вложений (`source`) для test-level и step-level attachments
+
+Локальный просмотр отчета:
+
+```bash
+allure serve allure-results
+```
+
 ### Настройка вывода в файл
 
 ```go

--- a/examples/allure_reporter_example_test.go
+++ b/examples/allure_reporter_example_test.go
@@ -1,0 +1,104 @@
+package examples
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nchursin/serenity-go/serenity/abilities/take_notes"
+	"github.com/nchursin/serenity-go/serenity/core"
+	"github.com/nchursin/serenity-go/serenity/reporting/allure_reporter"
+	serenity "github.com/nchursin/serenity-go/serenity/testing"
+)
+
+// TestAllureReporterExample_GeneratesReportFiles is a documentation-style example:
+// create an Allure reporter, run actor steps, then assert generated result files.
+func TestAllureReporterExample_GeneratesReportFiles(t *testing.T) {
+	resultsDir := t.TempDir()
+	reporter := allure_reporter.NewAllureReporterWithDir(resultsDir)
+
+	test := serenity.NewSerenityTest(t, serenity.Scene{
+		Context:  context.Background(),
+		Reporter: reporter,
+	})
+
+	actor := test.ActorCalled("Sam").WhoCan(take_notes.UsingEmptyNotepad())
+	actor.AttemptsTo(
+		core.Do("#actor does something", func(actor core.Actor, ctx context.Context) error {
+			return nil
+		}),
+		core.Do("#actor records an Allure-friendly step", func(actor core.Actor, ctx context.Context) error {
+			ability, err := actor.AbilityTo(&take_notes.TakeNotesAbility{})
+			if err != nil {
+				return err
+			}
+
+			notebook := ability.(*take_notes.TakeNotesAbility)
+			notebook.Set("token", "secret")
+			return nil
+		}),
+		core.Do("#actor does something else", func(actor core.Actor, ctx context.Context) error {
+			return nil
+		}),
+	)
+
+	test.Shutdown()
+
+	resultFile := findSingleAllureResultFile(t, resultsDir)
+	resultPayload, err := os.ReadFile(resultFile)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(resultPayload, &result))
+
+	require.Equal(t, "TestAllureReporterExample_GeneratesReportFiles", result["name"])
+	require.Equal(t, "passed", result["status"])
+
+	steps, ok := result["steps"].([]any)
+	require.True(t, ok)
+	require.Len(t, steps, 3)
+
+	attachments, ok := result["attachments"].([]any)
+	require.True(t, ok)
+	require.Len(t, attachments, 1)
+
+	notesAttachment, ok := attachments[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "notes", notesAttachment["name"])
+
+	source, ok := notesAttachment["source"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, source)
+
+	attachmentPayload, err := os.ReadFile(filepath.Join(resultsDir, source))
+	require.NoError(t, err)
+
+	var notes map[string]map[string]any
+	require.NoError(t, json.Unmarshal(attachmentPayload, &notes))
+	require.Equal(t, "secret", notes["Sam"]["token"])
+}
+
+func findSingleAllureResultFile(t *testing.T, resultsDir string) string {
+	t.Helper()
+
+	entries, err := os.ReadDir(resultsDir)
+	require.NoError(t, err)
+
+	resultFiles := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		resultFiles = append(resultFiles, filepath.Join(resultsDir, entry.Name()))
+	}
+
+	require.Len(t, resultFiles, 1)
+	return resultFiles[0]
+}

--- a/serenity/reporting/allure_reporter/allure_reporter.go
+++ b/serenity/reporting/allure_reporter/allure_reporter.go
@@ -1,0 +1,228 @@
+package allure_reporter
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/nchursin/serenity-go/serenity/reporting"
+)
+
+// AllureReporter writes Serenity events in Allure 2 result format.
+type AllureReporter struct {
+	resultsDir string
+
+	mutex   sync.Mutex
+	current *runningTest
+}
+
+type runningTest struct {
+	uuid      string
+	name      string
+	startMs   int64
+	steps     []allureStepResult
+	openSteps []openStep
+}
+
+type openStep struct {
+	name    string
+	startMs int64
+}
+
+type allureResult struct {
+	UUID          string             `json:"uuid"`
+	Name          string             `json:"name"`
+	Status        string             `json:"status"`
+	StatusDetails *allureStatus      `json:"statusDetails,omitempty"`
+	Start         int64              `json:"start"`
+	Stop          int64              `json:"stop"`
+	Steps         []allureStepResult `json:"steps,omitempty"`
+	Attachments   []allureAttachment `json:"attachments,omitempty"`
+}
+
+type allureStatus struct {
+	Message string `json:"message,omitempty"`
+}
+
+type allureStepResult struct {
+	Name        string             `json:"name"`
+	Status      string             `json:"status"`
+	Start       int64              `json:"start"`
+	Stop        int64              `json:"stop"`
+	Attachments []allureAttachment `json:"attachments,omitempty"`
+}
+
+type allureAttachment struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Type   string `json:"type"`
+}
+
+// NewAllureReporterWithDir creates a reporter that stores results in dir.
+func NewAllureReporterWithDir(dir string) *AllureReporter {
+	return &AllureReporter{resultsDir: dir}
+}
+
+func (ar *AllureReporter) SetOutput(_ io.Writer) {}
+
+func (ar *AllureReporter) OnTestStart(testName string) {
+	ar.mutex.Lock()
+	defer ar.mutex.Unlock()
+
+	ar.current = &runningTest{
+		uuid:    mustUUID(),
+		name:    testName,
+		startMs: time.Now().UnixMilli(),
+	}
+}
+
+func (ar *AllureReporter) OnStepStart(stepDescription string) {
+	ar.mutex.Lock()
+	defer ar.mutex.Unlock()
+
+	if ar.current == nil {
+		return
+	}
+
+	ar.current.openSteps = append(ar.current.openSteps, openStep{
+		name:    stepDescription,
+		startMs: time.Now().UnixMilli(),
+	})
+}
+
+func (ar *AllureReporter) OnStepFinish(stepResult reporting.TestResult) {
+	ar.mutex.Lock()
+	defer ar.mutex.Unlock()
+
+	if ar.current == nil {
+		return
+	}
+
+	startMs := time.Now().UnixMilli()
+	name := stepResult.Name()
+	if len(ar.current.openSteps) > 0 {
+		last := ar.current.openSteps[len(ar.current.openSteps)-1]
+		ar.current.openSteps = ar.current.openSteps[:len(ar.current.openSteps)-1]
+		startMs = last.startMs
+		if name == "" {
+			name = last.name
+		}
+	}
+
+	stopMs := endTime(startMs, stepResult.Duration())
+
+	attachments := ar.persistAttachments(stepResult.Attachments())
+	ar.current.steps = append(ar.current.steps, allureStepResult{
+		Name:        name,
+		Status:      mapStatus(stepResult.Status()),
+		Start:       startMs,
+		Stop:        stopMs,
+		Attachments: attachments,
+	})
+}
+
+func (ar *AllureReporter) OnTestFinish(result reporting.TestResult) {
+	ar.mutex.Lock()
+	defer ar.mutex.Unlock()
+
+	if ar.current == nil {
+		ar.current = &runningTest{
+			uuid:    mustUUID(),
+			name:    result.Name(),
+			startMs: time.Now().UnixMilli(),
+		}
+	}
+
+	if ar.current.name == "" {
+		ar.current.name = result.Name()
+	}
+
+	statusDetails := (*allureStatus)(nil)
+	if result.Error() != nil {
+		statusDetails = &allureStatus{Message: result.Error().Error()}
+	}
+
+	out := allureResult{
+		UUID:          ar.current.uuid,
+		Name:          ar.current.name,
+		Status:        mapStatus(result.Status()),
+		StatusDetails: statusDetails,
+		Start:         ar.current.startMs,
+		Stop:          endTime(ar.current.startMs, result.Duration()),
+		Steps:         ar.current.steps,
+		Attachments:   ar.persistAttachments(result.Attachments()),
+	}
+
+	_ = os.MkdirAll(ar.resultsDir, 0o750)
+	body, err := json.Marshal(out)
+	if err == nil {
+		_ = os.WriteFile(filepath.Join(ar.resultsDir, out.UUID+"-result.json"), body, 0o600)
+	}
+
+	ar.current = nil
+}
+
+func (ar *AllureReporter) persistAttachments(attachments []reporting.Attachment) []allureAttachment {
+	if len(attachments) == 0 {
+		return nil
+	}
+
+	_ = os.MkdirAll(ar.resultsDir, 0o750)
+
+	result := make([]allureAttachment, 0, len(attachments))
+	for _, att := range attachments {
+		source := mustUUID() + "-attachment"
+		if err := os.WriteFile(filepath.Join(ar.resultsDir, source), att.Content, 0o600); err != nil {
+			continue
+		}
+
+		result = append(result, allureAttachment{
+			Name:   att.Name,
+			Source: source,
+			Type:   att.ContentType,
+		})
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+
+	return result
+}
+
+func endTime(startMs int64, durationSeconds float64) int64 {
+	if durationSeconds <= 0 {
+		return startMs + 1
+	}
+
+	stopMs := startMs + int64(durationSeconds*1000)
+	if stopMs <= startMs {
+		return startMs + 1
+	}
+
+	return stopMs
+}
+
+func mapStatus(status reporting.Status) string {
+	switch status {
+	case reporting.StatusFailed:
+		return "failed"
+	case reporting.StatusSkipped:
+		return "skipped"
+	default:
+		return "passed"
+	}
+}
+
+func mustUUID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return time.Now().Format("20060102150405.000000000")
+	}
+	return hex.EncodeToString(b)
+}

--- a/serenity/reporting/allure_reporter/allure_reporter_test.go
+++ b/serenity/reporting/allure_reporter/allure_reporter_test.go
@@ -1,0 +1,251 @@
+package allure_reporter
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nchursin/serenity-go/serenity/reporting"
+)
+
+type stubResult struct {
+	name        string
+	status      reporting.Status
+	duration    float64
+	err         error
+	attachments []reporting.Attachment
+}
+
+func (sr *stubResult) Name() string {
+	return sr.name
+}
+
+func (sr *stubResult) Status() reporting.Status {
+	return sr.status
+}
+
+func (sr *stubResult) Duration() float64 {
+	return sr.duration
+}
+
+func (sr *stubResult) Error() error {
+	return sr.err
+}
+
+func (sr *stubResult) Attachments() []reporting.Attachment {
+	return sr.attachments
+}
+
+func TestAllureReporter_WritesResultFile(t *testing.T) {
+	t.Parallel()
+
+	resultsDir := t.TempDir()
+	r := NewAllureReporterWithDir(resultsDir)
+
+	r.OnTestStart("SampleTest")
+	r.OnTestFinish(&stubResult{name: "SampleTest", status: reporting.StatusPassed, duration: 0.01})
+
+	result := readSingleResultFile(t, resultsDir)
+	require.Equal(t, "SampleTest", result.Name)
+	require.Equal(t, "passed", result.Status)
+	require.NotEmpty(t, result.UUID)
+	require.Greater(t, result.Stop, result.Start)
+}
+
+func TestAllureReporter_MapsStatus(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		status       reporting.Status
+		expected     string
+		expectedName string
+	}{
+		{name: "passed", status: reporting.StatusPassed, expected: "passed", expectedName: "PassedStatus"},
+		{name: "failed", status: reporting.StatusFailed, expected: "failed", expectedName: "FailedStatus"},
+		{name: "skipped", status: reporting.StatusSkipped, expected: "skipped", expectedName: "SkippedStatus"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resultsDir := t.TempDir()
+			r := NewAllureReporterWithDir(resultsDir)
+
+			r.OnTestStart(tc.expectedName)
+			r.OnTestFinish(&stubResult{name: tc.expectedName, status: tc.status, duration: 0.01})
+
+			result := readSingleResultFile(t, resultsDir)
+			require.Equal(t, tc.expected, result.Status)
+		})
+	}
+}
+
+func TestAllureReporter_WritesStatusDetails(t *testing.T) {
+	t.Parallel()
+
+	resultsDir := t.TempDir()
+	r := NewAllureReporterWithDir(resultsDir)
+
+	r.OnTestStart("FailedWithError")
+	r.OnTestFinish(&stubResult{
+		name:     "FailedWithError",
+		status:   reporting.StatusFailed,
+		duration: 0.01,
+		err:      errors.New("boom"),
+	})
+
+	result := readSingleResultFile(t, resultsDir)
+	require.Equal(t, "failed", result.Status)
+	require.NotNil(t, result.StatusDetails)
+	require.Contains(t, result.StatusDetails.Message, "boom")
+}
+
+func TestAllureReporter_RecordsSteps(t *testing.T) {
+	t.Parallel()
+
+	resultsDir := t.TempDir()
+	r := NewAllureReporterWithDir(resultsDir)
+
+	r.OnTestStart("StepTest")
+	r.OnStepStart("does important step")
+	r.OnStepFinish(&stubResult{name: "does important step", status: reporting.StatusPassed, duration: 0.02})
+	r.OnTestFinish(&stubResult{name: "StepTest", status: reporting.StatusPassed, duration: 0.03})
+
+	result := readSingleResultFile(t, resultsDir)
+	require.Len(t, result.Steps, 1)
+	require.Equal(t, "does important step", result.Steps[0].Name)
+	require.Equal(t, "passed", result.Steps[0].Status)
+	require.Greater(t, result.Steps[0].Stop, result.Steps[0].Start)
+}
+
+func TestAllureReporter_WritesTestAttachments(t *testing.T) {
+	t.Parallel()
+
+	resultsDir := t.TempDir()
+	r := NewAllureReporterWithDir(resultsDir)
+
+	r.OnTestStart("AttachmentTest")
+	r.OnTestFinish(&stubResult{
+		name:     "AttachmentTest",
+		status:   reporting.StatusPassed,
+		duration: 0.01,
+		attachments: []reporting.Attachment{
+			{
+				Name:        "notes",
+				ContentType: "application/json",
+				Content:     []byte(`{"ok":true}`),
+			},
+		},
+	})
+
+	result := readSingleResultFile(t, resultsDir)
+	require.Len(t, result.Attachments, 1)
+	require.Equal(t, "notes", result.Attachments[0].Name)
+	require.Equal(t, "application/json", result.Attachments[0].Type)
+	require.NotEmpty(t, result.Attachments[0].Source)
+
+	payload, err := os.ReadFile(filepath.Join(resultsDir, result.Attachments[0].Source))
+	require.NoError(t, err)
+	require.JSONEq(t, `{"ok":true}`, string(payload))
+}
+
+func TestAllureReporter_WritesStepAttachments(t *testing.T) {
+	t.Parallel()
+
+	resultsDir := t.TempDir()
+	r := NewAllureReporterWithDir(resultsDir)
+
+	r.OnTestStart("StepAttachmentTest")
+	r.OnStepStart("captures evidence")
+	r.OnStepFinish(&stubResult{
+		name:     "captures evidence",
+		status:   reporting.StatusPassed,
+		duration: 0.02,
+		attachments: []reporting.Attachment{
+			{
+				Name:        "response",
+				ContentType: "application/json",
+				Content:     []byte(`{"status":200}`),
+			},
+		},
+	})
+	r.OnTestFinish(&stubResult{name: "StepAttachmentTest", status: reporting.StatusPassed, duration: 0.03})
+
+	result := readSingleResultFile(t, resultsDir)
+	require.Len(t, result.Steps, 1)
+	require.Len(t, result.Steps[0].Attachments, 1)
+	require.Equal(t, "response", result.Steps[0].Attachments[0].Name)
+	require.Equal(t, "application/json", result.Steps[0].Attachments[0].Type)
+
+	source := result.Steps[0].Attachments[0].Source
+	payload, err := os.ReadFile(filepath.Join(resultsDir, source))
+	require.NoError(t, err)
+	require.JSONEq(t, `{"status":200}`, string(payload))
+}
+
+type expectedResultFile struct {
+	UUID          string               `json:"uuid"`
+	Name          string               `json:"name"`
+	Status        string               `json:"status"`
+	StatusDetails *expectedStatus      `json:"statusDetails,omitempty"`
+	Start         int64                `json:"start"`
+	Stop          int64                `json:"stop"`
+	Steps         []expectedStep       `json:"steps,omitempty"`
+	Attachments   []expectedAttachment `json:"attachments,omitempty"`
+}
+
+type expectedStatus struct {
+	Message string `json:"message,omitempty"`
+}
+
+type expectedStep struct {
+	Name        string               `json:"name"`
+	Status      string               `json:"status"`
+	Start       int64                `json:"start"`
+	Stop        int64                `json:"stop"`
+	Attachments []expectedAttachment `json:"attachments,omitempty"`
+}
+
+type expectedAttachment struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Type   string `json:"type"`
+}
+
+func readSingleResultFile(t *testing.T, resultsDir string) expectedResultFile {
+	t.Helper()
+
+	entries, err := os.ReadDir(resultsDir)
+	require.NoError(t, err)
+
+	resultFiles := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		if filepath.Base(entry.Name()) == "categories.json" {
+			continue
+		}
+		resultFiles = append(resultFiles, filepath.Join(resultsDir, entry.Name()))
+	}
+
+	require.Len(t, resultFiles, 1)
+
+	content, err := os.ReadFile(resultFiles[0])
+	require.NoError(t, err)
+
+	var result expectedResultFile
+	err = json.Unmarshal(content, &result)
+	require.NoError(t, err)
+
+	return result
+}

--- a/serenity/testing/allure_reporter_integration_test.go
+++ b/serenity/testing/allure_reporter_integration_test.go
@@ -1,0 +1,86 @@
+package testing
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nchursin/serenity-go/serenity/abilities/take_notes"
+	"github.com/nchursin/serenity-go/serenity/core"
+	"github.com/nchursin/serenity-go/serenity/reporting/allure_reporter"
+)
+
+func TestSerenityTest_WithAllureReporter_WritesResults(t *testing.T) {
+	t.Parallel()
+
+	resultsDir := t.TempDir()
+	reporter := allure_reporter.NewAllureReporterWithDir(resultsDir)
+
+	test := NewSerenityTest(t, Scene{
+		Context:  context.Background(),
+		Reporter: reporter,
+	})
+
+	actor := test.ActorCalled("Sam").WhoCan(take_notes.UsingEmptyNotepad())
+	ability, err := actor.AbilityTo(&take_notes.TakeNotesAbility{})
+	require.NoError(t, err)
+	notebook := ability.(*take_notes.TakeNotesAbility)
+	notebook.Set("token", "secret")
+
+	actor.AttemptsTo(core.Do("records an action", func(actor core.Actor, ctx context.Context) error {
+		return nil
+	}))
+
+	test.Shutdown()
+
+	resultPath := readResultFilePath(t, resultsDir)
+	payload, err := os.ReadFile(resultPath)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(payload, &result))
+
+	steps, ok := result["steps"].([]any)
+	require.True(t, ok)
+	require.Len(t, steps, 1)
+
+	attachments, ok := result["attachments"].([]any)
+	require.True(t, ok)
+	require.Len(t, attachments, 1)
+
+	attachment := attachments[0].(map[string]any)
+	require.Equal(t, "notes", attachment["name"])
+
+	source := attachment["source"].(string)
+	attachmentPayload, err := os.ReadFile(filepath.Join(resultsDir, source))
+	require.NoError(t, err)
+
+	var notesJSON map[string]map[string]any
+	require.NoError(t, json.Unmarshal(attachmentPayload, &notesJSON))
+	require.Equal(t, "secret", notesJSON["Sam"]["token"])
+}
+
+func readResultFilePath(t *testing.T, dir string) string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	results := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		results = append(results, filepath.Join(dir, entry.Name()))
+	}
+
+	require.Len(t, results, 1)
+	return results[0]
+}


### PR DESCRIPTION
## Summary
- add native `allure_reporter` implementing Serenity `reporting.Reporter` with test/step lifecycle and attachment persistence
- add integration coverage in `serenity/testing` and a documentation-style example test in `examples`
- document Allure usage in `README.md` and `docs/reporting.md`

## Test Plan
- [x] go test ./...

Resolves #7