### PR TITLE
Preserve nested task step hierarchy in reports

### DIFF
--- a/examples/allure_reporter_example_test.go
+++ b/examples/allure_reporter_example_test.go
@@ -81,6 +81,53 @@ func TestAllureReporterExample_GeneratesReportFiles(t *testing.T) {
 	require.Equal(t, "secret", notes["Sam"]["token"])
 }
 
+func TestAllureReporterExample_GeneratesNestedTaskSteps(t *testing.T) {
+	resultsDir := t.TempDir()
+	reporter := allure_reporter.NewAllureReporterWithDir(resultsDir)
+
+	test := verity.NewVerityTest(t, verity.Scene{
+		Context:  context.Background(),
+		Reporter: reporter,
+	})
+
+	actor := test.ActorCalled("Sam")
+	actor.AttemptsTo(
+		verity.TaskWhere("#actor creates an order",
+			verity.TaskWhere("#actor submits order details",
+				verity.Do("#actor opens order page", func(ctx context.Context, actor verity.Actor) error {
+					return nil
+				}),
+			),
+		),
+	)
+
+	test.Shutdown()
+
+	resultFile := findSingleAllureResultFile(t, resultsDir)
+	resultPayload, err := os.ReadFile(resultFile)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(resultPayload, &result))
+
+	steps, ok := result["steps"].([]any)
+	require.True(t, ok)
+	require.Len(t, steps, 1)
+
+	rootStep := steps[0].(map[string]any)
+	require.Equal(t, "Sam creates an order", rootStep["name"])
+
+	nestedSteps, ok := rootStep["steps"].([]any)
+	require.True(t, ok)
+	require.Len(t, nestedSteps, 1)
+	require.Equal(t, "Sam submits order details", nestedSteps[0].(map[string]any)["name"])
+
+	leafSteps, ok := nestedSteps[0].(map[string]any)["steps"].([]any)
+	require.True(t, ok)
+	require.Len(t, leafSteps, 1)
+	require.Equal(t, "Sam opens order page", leafSteps[0].(map[string]any)["name"])
+}
+
 func findSingleAllureResultFile(t *testing.T, resultsDir string) string {
 	t.Helper()
 

--- a/internal/core/activity.go
+++ b/internal/core/activity.go
@@ -5,6 +5,18 @@ import (
 	"fmt"
 )
 
+type activityPerformer interface {
+	PerformActivity(ctx context.Context, activity Activity) error
+}
+
+func performActivity(ctx context.Context, actor Actor, activity Activity) error {
+	if performer, ok := actor.(activityPerformer); ok {
+		return performer.PerformActivity(ctx, activity)
+	}
+
+	return activity.PerformAs(ctx, actor)
+}
+
 // This file provides concrete implementations of the Activity interface
 // defined in interfaces.go. These implementations enable the creation
 // of both atomic interactions and composed tasks for test scenarios.
@@ -104,13 +116,7 @@ func (t *task) Description() string {
 //	- The original error wrapped with context
 func (t *task) PerformAs(ctx context.Context, actor Actor) error {
 	for _, activity := range t.activities {
-		var err error
-		if performer, ok := actor.(NestedActivityPerformer); ok {
-			err = performer.PerformNestedActivity(ctx, activity)
-		} else {
-			err = activity.PerformAs(ctx, actor)
-		}
-
+		err := performActivity(ctx, actor, activity)
 		if err != nil {
 			return fmt.Errorf("task '%s' failed during activity '%s': %w",
 				t.Description(), activity.Description(), err)

--- a/internal/core/activity.go
+++ b/internal/core/activity.go
@@ -104,7 +104,14 @@ func (t *task) Description() string {
 //	- The original error wrapped with context
 func (t *task) PerformAs(ctx context.Context, actor Actor) error {
 	for _, activity := range t.activities {
-		if err := activity.PerformAs(ctx, actor); err != nil {
+		var err error
+		if performer, ok := actor.(NestedActivityPerformer); ok {
+			err = performer.PerformNestedActivity(ctx, activity)
+		} else {
+			err = activity.PerformAs(ctx, actor)
+		}
+
+		if err != nil {
 			return fmt.Errorf("task '%s' failed during activity '%s': %w",
 				t.Description(), activity.Description(), err)
 		}

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -320,6 +320,13 @@ type Actor interface {
 	AnswersTo(question Question[any]) (any, bool)
 }
 
+// NestedActivityPerformer is an internal extension point used by task execution
+// to delegate child activities back through an actor-specific execution pipeline.
+// It intentionally sits outside Actor so the public Actor API stays unchanged.
+type NestedActivityPerformer interface {
+	PerformNestedActivity(ctx context.Context, activity Activity) error
+}
+
 // Activity represents an action that an actor can perform.
 // Activities are the building blocks of test scenarios in the Screenplay Pattern.
 // They define what actors do rather than how they interact with specific interfaces.

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -320,13 +320,6 @@ type Actor interface {
 	AnswersTo(question Question[any]) (any, bool)
 }
 
-// NestedActivityPerformer is an internal extension point used by task execution
-// to delegate child activities back through an actor-specific execution pipeline.
-// It intentionally sits outside Actor so the public Actor API stays unchanged.
-type NestedActivityPerformer interface {
-	PerformNestedActivity(ctx context.Context, activity Activity) error
-}
-
 // Activity represents an action that an actor can perform.
 // Activities are the building blocks of test scenarios in the Screenplay Pattern.
 // They define what actors do rather than how they interact with specific interfaces.

--- a/internal/reporting/allure_reporter/allure_reporter.go
+++ b/internal/reporting/allure_reporter/allure_reporter.go
@@ -30,8 +30,9 @@ type runningTest struct {
 }
 
 type openStep struct {
-	name    string
-	startMs int64
+	name     string
+	startMs  int64
+	children []allureStepResult
 }
 
 type allureResult struct {
@@ -54,6 +55,7 @@ type allureStepResult struct {
 	Status      string             `json:"status"`
 	Start       int64              `json:"start"`
 	Stop        int64              `json:"stop"`
+	Steps       []allureStepResult `json:"steps,omitempty"`
 	Attachments []allureAttachment `json:"attachments,omitempty"`
 }
 
@@ -105,25 +107,35 @@ func (ar *AllureReporter) OnStepFinish(stepResult reporting.TestResult) {
 
 	startMs := time.Now().UnixMilli()
 	name := stepResult.Name()
+	var finished openStep
 	if len(ar.current.openSteps) > 0 {
-		last := ar.current.openSteps[len(ar.current.openSteps)-1]
+		finished = ar.current.openSteps[len(ar.current.openSteps)-1]
 		ar.current.openSteps = ar.current.openSteps[:len(ar.current.openSteps)-1]
-		startMs = last.startMs
+		startMs = finished.startMs
 		if name == "" {
-			name = last.name
+			name = finished.name
 		}
 	}
 
 	stopMs := endTime(startMs, stepResult.Duration())
 
 	attachments := ar.persistAttachments(stepResult.Attachments())
-	ar.current.steps = append(ar.current.steps, allureStepResult{
+	step := allureStepResult{
 		Name:        name,
 		Status:      mapStatus(stepResult.Status()),
 		Start:       startMs,
 		Stop:        stopMs,
+		Steps:       finished.children,
 		Attachments: attachments,
-	})
+	}
+
+	if len(ar.current.openSteps) == 0 {
+		ar.current.steps = append(ar.current.steps, step)
+		return
+	}
+
+	parentIndex := len(ar.current.openSteps) - 1
+	ar.current.openSteps[parentIndex].children = append(ar.current.openSteps[parentIndex].children, step)
 }
 
 func (ar *AllureReporter) OnTestFinish(result reporting.TestResult) {

--- a/internal/reporting/allure_reporter/allure_reporter_test.go
+++ b/internal/reporting/allure_reporter/allure_reporter_test.go
@@ -124,6 +124,27 @@ func TestAllureReporter_RecordsSteps(t *testing.T) {
 	require.Greater(t, result.Steps[0].Stop, result.Steps[0].Start)
 }
 
+func TestAllureReporter_RecordsNestedSteps(t *testing.T) {
+	t.Parallel()
+
+	resultsDir := t.TempDir()
+	r := NewAllureReporterWithDir(resultsDir)
+
+	r.OnTestStart("NestedStepTest")
+	r.OnStepStart("creates an order")
+	r.OnStepStart("opens order page")
+	r.OnStepFinish(&stubResult{name: "opens order page", status: reporting.StatusPassed, duration: 0.01})
+	r.OnStepFinish(&stubResult{name: "creates an order", status: reporting.StatusPassed, duration: 0.02})
+	r.OnTestFinish(&stubResult{name: "NestedStepTest", status: reporting.StatusPassed, duration: 0.03})
+
+	result := readSingleResultFile(t, resultsDir)
+	require.Len(t, result.Steps, 1)
+	require.Equal(t, "creates an order", result.Steps[0].Name)
+	require.Len(t, result.Steps[0].Steps, 1)
+	require.Equal(t, "opens order page", result.Steps[0].Steps[0].Name)
+	require.Equal(t, "passed", result.Steps[0].Steps[0].Status)
+}
+
 func TestAllureReporter_WritesTestAttachments(t *testing.T) {
 	t.Parallel()
 
@@ -209,6 +230,7 @@ type expectedStep struct {
 	Status      string               `json:"status"`
 	Start       int64                `json:"start"`
 	Stop        int64                `json:"stop"`
+	Steps       []expectedStep       `json:"steps,omitempty"`
 	Attachments []expectedAttachment `json:"attachments,omitempty"`
 }
 

--- a/internal/reporting/allure_reporter/allure_reporter_test.go
+++ b/internal/reporting/allure_reporter/allure_reporter_test.go
@@ -145,6 +145,30 @@ func TestAllureReporter_RecordsNestedSteps(t *testing.T) {
 	require.Equal(t, "passed", result.Steps[0].Steps[0].Status)
 }
 
+func TestAllureReporter_RecordsNestedStepsAtMultipleLevels(t *testing.T) {
+	t.Parallel()
+
+	resultsDir := t.TempDir()
+	r := NewAllureReporterWithDir(resultsDir)
+
+	r.OnTestStart("NestedTaskTreeTest")
+	r.OnStepStart("creates an order")
+	r.OnStepStart("submits order details")
+	r.OnStepStart("opens order page")
+	r.OnStepFinish(&stubResult{name: "opens order page", status: reporting.StatusPassed, duration: 0.01})
+	r.OnStepFinish(&stubResult{name: "submits order details", status: reporting.StatusPassed, duration: 0.02})
+	r.OnStepFinish(&stubResult{name: "creates an order", status: reporting.StatusPassed, duration: 0.03})
+	r.OnTestFinish(&stubResult{name: "NestedTaskTreeTest", status: reporting.StatusPassed, duration: 0.04})
+
+	result := readSingleResultFile(t, resultsDir)
+	require.Len(t, result.Steps, 1)
+	require.Equal(t, "creates an order", result.Steps[0].Name)
+	require.Len(t, result.Steps[0].Steps, 1)
+	require.Equal(t, "submits order details", result.Steps[0].Steps[0].Name)
+	require.Len(t, result.Steps[0].Steps[0].Steps, 1)
+	require.Equal(t, "opens order page", result.Steps[0].Steps[0].Steps[0].Name)
+}
+
 func TestAllureReporter_WritesTestAttachments(t *testing.T) {
 	t.Parallel()
 

--- a/internal/testing/actor.go
+++ b/internal/testing/actor.go
@@ -106,17 +106,7 @@ func (ta *testActor) AbilityTo(abilityType abilities.Ability) (abilities.Ability
 //   - Ignore: Silently ignores the error and continues
 func (ta *testActor) AttemptsTo(activities ...core.Activity) {
 	for _, activity := range activities {
-		var tracker *reporting.ActivityTracker
-		if ta.reporter != nil {
-			tracker = reporting.NewActivityTrackerWithActor(ta.reporter.GetReporter(), activity.Description(), ta.name)
-			tracker.Start()
-		}
-
-		err := activity.PerformAs(ta.ctx, ta)
-
-		if tracker != nil {
-			tracker.Finish(err)
-		}
+		err := ta.performActivity(ta.ctx, activity)
 
 		if err != nil {
 			failureMode := activity.FailureMode()
@@ -132,6 +122,28 @@ func (ta *testActor) AttemptsTo(activities ...core.Activity) {
 			}
 		}
 	}
+}
+
+// PerformNestedActivity executes a child activity within a parent task while
+// preserving the same reporting pipeline as top-level activities.
+func (ta *testActor) PerformNestedActivity(ctx context.Context, activity core.Activity) error {
+	return ta.performActivity(ctx, activity)
+}
+
+func (ta *testActor) performActivity(ctx context.Context, activity core.Activity) error {
+	var tracker *reporting.ActivityTracker
+	if ta.reporter != nil {
+		tracker = reporting.NewActivityTrackerWithActor(ta.reporter.GetReporter(), activity.Description(), ta.name)
+		tracker.Start()
+	}
+
+	err := activity.PerformAs(ctx, ta)
+
+	if tracker != nil {
+		tracker.Finish(err)
+	}
+
+	return err
 }
 
 // AnswersTo answers questions with boolean success flag

--- a/internal/testing/actor.go
+++ b/internal/testing/actor.go
@@ -106,7 +106,7 @@ func (ta *testActor) AbilityTo(abilityType abilities.Ability) (abilities.Ability
 //   - Ignore: Silently ignores the error and continues
 func (ta *testActor) AttemptsTo(activities ...core.Activity) {
 	for _, activity := range activities {
-		err := ta.performActivity(ta.ctx, activity)
+		err := ta.PerformActivity(ta.ctx, activity)
 
 		if err != nil {
 			failureMode := activity.FailureMode()
@@ -124,13 +124,9 @@ func (ta *testActor) AttemptsTo(activities ...core.Activity) {
 	}
 }
 
-// PerformNestedActivity executes a child activity within a parent task while
-// preserving the same reporting pipeline as top-level activities.
-func (ta *testActor) PerformNestedActivity(ctx context.Context, activity core.Activity) error {
-	return ta.performActivity(ctx, activity)
-}
-
-func (ta *testActor) performActivity(ctx context.Context, activity core.Activity) error {
+// PerformActivity executes a single activity through the actor reporting pipeline
+// and returns the underlying execution error to the caller.
+func (ta *testActor) PerformActivity(ctx context.Context, activity core.Activity) error {
 	var tracker *reporting.ActivityTracker
 	if ta.reporter != nil {
 		tracker = reporting.NewActivityTrackerWithActor(ta.reporter.GetReporter(), activity.Description(), ta.name)

--- a/internal/testing/actor_test.go
+++ b/internal/testing/actor_test.go
@@ -113,6 +113,55 @@ func TestTestActorAttemptsToWithNestedTaskReporting(t *testing.T) {
 	)
 }
 
+func TestTestActorPerformActivityReportsNestedTaskHierarchy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReporter := reportingMocks.NewMockReporter(ctrl)
+	mockTestContext := testingMocks.NewMockTestContext(ctrl)
+
+	gomock.InOrder(
+		mockReporter.EXPECT().OnStepStart("Sam creates an order"),
+		mockReporter.EXPECT().OnStepStart("Sam submits order details"),
+		mockReporter.EXPECT().OnStepStart("Sam opens order page"),
+		mockReporter.EXPECT().OnStepFinish(gomock.Any()).Do(func(result reporting.TestResult) {
+			if result.Name() != "Sam opens order page" {
+				t.Fatalf("unexpected leaf step name: %s", result.Name())
+			}
+		}),
+		mockReporter.EXPECT().OnStepFinish(gomock.Any()).Do(func(result reporting.TestResult) {
+			if result.Name() != "Sam submits order details" {
+				t.Fatalf("unexpected nested task name: %s", result.Name())
+			}
+		}),
+		mockReporter.EXPECT().OnStepFinish(gomock.Any()).Do(func(result reporting.TestResult) {
+			if result.Name() != "Sam creates an order" {
+				t.Fatalf("unexpected root task name: %s", result.Name())
+			}
+		}),
+	)
+
+	actor := &testActor{
+		name:        "Sam",
+		testContext: mockTestContext,
+		reporter:    reporting.NewTestRunnerAdapter(mockReporter),
+		ctx:         context.Background(),
+	}
+
+	err := actor.PerformActivity(context.Background(),
+		core.TaskWhere("#actor creates an order",
+			core.TaskWhere("#actor submits order details",
+				core.Do("#actor opens order page", func(ctx context.Context, actor core.Actor) error {
+					return nil
+				}),
+			),
+		),
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
 func TestAbilityToReturnsFriendlyError(t *testing.T) {
 	actor := &testActor{
 		name:      "TestActor",

--- a/internal/testing/actor_test.go
+++ b/internal/testing/actor_test.go
@@ -62,6 +62,57 @@ func TestTestActorAttemptsToWithReporting(t *testing.T) {
 	actor.AttemptsTo(mockActivity)
 }
 
+func TestTestActorAttemptsToWithNestedTaskReporting(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReporter := reportingMocks.NewMockReporter(ctrl)
+	mockTestContext := testingMocks.NewMockTestContext(ctrl)
+
+	gomock.InOrder(
+		mockReporter.EXPECT().OnStepStart("Sam creates an order"),
+		mockReporter.EXPECT().OnStepStart("Sam opens order page"),
+		mockReporter.EXPECT().OnStepFinish(gomock.Any()).Do(func(result reporting.TestResult) {
+			if result.Name() != "Sam opens order page" {
+				t.Fatalf("unexpected child step name: %s", result.Name())
+			}
+		}),
+		mockReporter.EXPECT().OnStepStart("Sam saves order"),
+		mockReporter.EXPECT().OnStepFinish(gomock.Any()).Do(func(result reporting.TestResult) {
+			if result.Name() != "Sam saves order" {
+				t.Fatalf("unexpected child step name: %s", result.Name())
+			}
+		}),
+		mockReporter.EXPECT().OnStepFinish(gomock.Any()).Do(func(result reporting.TestResult) {
+			if result.Name() != "Sam creates an order" {
+				t.Fatalf("unexpected task step name: %s", result.Name())
+			}
+		}),
+	)
+
+	mockTestContext.EXPECT().Failed().Return(false).AnyTimes()
+
+	adapter := reporting.NewTestRunnerAdapter(mockReporter)
+	test := &verityTest{
+		testCtx: mockTestContext,
+		ctx:     context.Background(),
+		actors:  make(map[string]core.Actor),
+		adapter: adapter,
+	}
+
+	actor := test.ActorCalled("Sam")
+	actor.AttemptsTo(
+		core.TaskWhere("#actor creates an order",
+			core.Do("#actor opens order page", func(ctx context.Context, actor core.Actor) error {
+				return nil
+			}),
+			core.Do("#actor saves order", func(ctx context.Context, actor core.Actor) error {
+				return nil
+			}),
+		),
+	)
+}
+
 func TestAbilityToReturnsFriendlyError(t *testing.T) {
 	actor := &testActor{
 		name:      "TestActor",

--- a/internal/testing/allure_reporter_integration_test.go
+++ b/internal/testing/allure_reporter_integration_test.go
@@ -64,6 +64,52 @@ func TestVerityTest_WithAllureReporter_WritesResults(t *testing.T) {
 	require.Equal(t, "secret", notesJSON["Sam"]["token"])
 }
 
+func TestVerityTest_WithAllureReporter_WritesNestedTaskResults(t *testing.T) {
+	t.Parallel()
+
+	resultsDir := t.TempDir()
+	reporter := allure_reporter.NewAllureReporterWithDir(resultsDir)
+
+	test := NewVerityTest(t, Scene{
+		Context:  context.Background(),
+		Reporter: reporter,
+	})
+
+	actor := test.ActorCalled("Sam")
+	actor.AttemptsTo(
+		core.TaskWhere("#actor creates an order",
+			core.Do("#actor opens order page", func(ctx context.Context, actor core.Actor) error {
+				return nil
+			}),
+			core.Do("#actor saves order", func(ctx context.Context, actor core.Actor) error {
+				return nil
+			}),
+		),
+	)
+
+	test.Shutdown()
+
+	resultPath := readResultFilePath(t, resultsDir)
+	payload, err := os.ReadFile(resultPath)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(payload, &result))
+
+	steps, ok := result["steps"].([]any)
+	require.True(t, ok)
+	require.Len(t, steps, 1)
+
+	taskStep := steps[0].(map[string]any)
+	require.Equal(t, "Sam creates an order", taskStep["name"])
+
+	childSteps, ok := taskStep["steps"].([]any)
+	require.True(t, ok)
+	require.Len(t, childSteps, 2)
+	require.Equal(t, "Sam opens order page", childSteps[0].(map[string]any)["name"])
+	require.Equal(t, "Sam saves order", childSteps[1].(map[string]any)["name"])
+}
+
 func readResultFilePath(t *testing.T, dir string) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- route task child activities through the actor reporting pipeline so nested task steps emit start/finish events in order
- update the Allure reporter to build nested `steps` trees instead of flattening task and activity entries
- add regression coverage for nested task reporting in actor, Allure unit, and Allure integration tests

## Test Plan
- `go test ./...`