### PR TITLE
fix(expectations): make IsEmpty and ArrayLengthEquals generic

### DIFF
--- a/internal/expectations/collection.go
+++ b/internal/expectations/collection.go
@@ -7,16 +7,11 @@ import (
 	"github.com/nchursin/verity-bdd/internal/expectations/ensure"
 )
 
-// IsEmptyExpectation checks if a string is empty
-type IsEmptyExpectation struct{}
-
-// NewIsEmpty creates a new IsEmpty expectation
-func NewIsEmpty() ensure.Expectation[interface{}] {
-	return IsEmptyExpectation{}
-}
+// IsEmptyExpectation checks if a value is empty (string, slice, array, or map)
+type IsEmptyExpectation[T any] struct{}
 
 // Evaluate evaluates the is empty expectation
-func (ie IsEmptyExpectation) Evaluate(actual interface{}) error {
+func (ie IsEmptyExpectation[T]) Evaluate(actual T) error {
 	val := reflect.ValueOf(actual)
 
 	switch val.Kind() {
@@ -40,27 +35,22 @@ func (ie IsEmptyExpectation) Evaluate(actual interface{}) error {
 }
 
 // Description returns the expectation description
-func (ie IsEmptyExpectation) Description() string {
+func (ie IsEmptyExpectation[T]) Description() string {
 	return "is empty"
 }
 
-// Convenience function for creating IsEmpty expectations
-func IsEmpty() ensure.Expectation[interface{}] {
-	return NewIsEmpty()
+// IsEmpty creates an IsEmpty expectation for the given type
+func IsEmpty[T any]() ensure.Expectation[T] {
+	return IsEmptyExpectation[T]{}
 }
 
-// ArrayLengthEqualsExpectation checks if an array/slice has the expected length
-type ArrayLengthEqualsExpectation struct {
+// ArrayLengthEqualsExpectation checks if an array/slice/string has the expected length
+type ArrayLengthEqualsExpectation[T any] struct {
 	expectedLength int
 }
 
-// NewArrayLengthEquals creates a new ArrayLengthEquals expectation
-func NewArrayLengthEquals(expectedLength int) ensure.Expectation[interface{}] {
-	return ArrayLengthEqualsExpectation{expectedLength: expectedLength}
-}
-
 // Evaluate evaluates the array length expectation
-func (ale ArrayLengthEqualsExpectation) Evaluate(actual interface{}) error {
+func (ale ArrayLengthEqualsExpectation[T]) Evaluate(actual T) error {
 	val := reflect.ValueOf(actual)
 
 	var length int
@@ -80,11 +70,11 @@ func (ale ArrayLengthEqualsExpectation) Evaluate(actual interface{}) error {
 }
 
 // Description returns the expectation description
-func (ale ArrayLengthEqualsExpectation) Description() string {
+func (ale ArrayLengthEqualsExpectation[T]) Description() string {
 	return fmt.Sprintf("has length %d", ale.expectedLength)
 }
 
-// Convenience function for creating ArrayLengthEquals expectations
-func ArrayLengthEquals(expectedLength int) ensure.Expectation[interface{}] {
-	return NewArrayLengthEquals(expectedLength)
+// ArrayLengthEquals creates an ArrayLengthEquals expectation for the given type
+func ArrayLengthEquals[T any](expectedLength int) ensure.Expectation[T] {
+	return ArrayLengthEqualsExpectation[T]{expectedLength: expectedLength}
 }

--- a/internal/expectations/collection_test.go
+++ b/internal/expectations/collection_test.go
@@ -1,0 +1,89 @@
+package expectations_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nchursin/verity-bdd/internal/expectations"
+)
+
+// IsEmpty — slice tests (issue #21)
+
+func TestIsEmpty_PassesOnEmptySlice(t *testing.T) {
+	err := expectations.IsEmpty[[]int]().Evaluate([]int{})
+	assert.NoError(t, err)
+}
+
+func TestIsEmpty_FailsOnNonEmptySlice(t *testing.T) {
+	err := expectations.IsEmpty[[]int]().Evaluate([]int{1, 2, 3})
+	require.Error(t, err)
+	assert.Equal(t, "expected slice/array to be empty, but got 3 elements", err.Error())
+}
+
+// IsEmpty — string regression
+
+func TestIsEmpty_PassesOnEmptyString(t *testing.T) {
+	err := expectations.IsEmpty[string]().Evaluate("")
+	assert.NoError(t, err)
+}
+
+func TestIsEmpty_FailsOnNonEmptyString(t *testing.T) {
+	err := expectations.IsEmpty[string]().Evaluate("hello")
+	require.Error(t, err)
+	assert.Equal(t, "expected string to be empty, but got 'hello'", err.Error())
+}
+
+// IsEmpty — map regression
+
+func TestIsEmpty_PassesOnEmptyMap(t *testing.T) {
+	err := expectations.IsEmpty[map[string]int]().Evaluate(map[string]int{})
+	assert.NoError(t, err)
+}
+
+func TestIsEmpty_FailsOnNonEmptyMap(t *testing.T) {
+	err := expectations.IsEmpty[map[string]int]().Evaluate(map[string]int{"a": 1})
+	require.Error(t, err)
+	assert.Equal(t, "expected map to be empty, but got 1 elements", err.Error())
+}
+
+// IsEmpty — Description
+
+func TestIsEmpty_Description(t *testing.T) {
+	desc := expectations.IsEmpty[[]int]().Description()
+	assert.Equal(t, "is empty", desc)
+}
+
+// ArrayLengthEquals — slice tests
+
+func TestArrayLengthEquals_PassesOnMatchingSlice(t *testing.T) {
+	err := expectations.ArrayLengthEquals[[]int](3).Evaluate([]int{1, 2, 3})
+	assert.NoError(t, err)
+}
+
+func TestArrayLengthEquals_FailsOnWrongLengthSlice(t *testing.T) {
+	err := expectations.ArrayLengthEquals[[]int](3).Evaluate([]int{1, 2})
+	require.Error(t, err)
+	assert.Equal(t, "expected length to be 3, but got 2", err.Error())
+}
+
+// ArrayLengthEquals — string regression
+
+func TestArrayLengthEquals_PassesOnMatchingString(t *testing.T) {
+	err := expectations.ArrayLengthEquals[string](5).Evaluate("hello")
+	assert.NoError(t, err)
+}
+
+func TestArrayLengthEquals_FailsOnWrongLengthString(t *testing.T) {
+	err := expectations.ArrayLengthEquals[string](5).Evaluate("hi")
+	require.Error(t, err)
+	assert.Equal(t, "expected length to be 5, but got 2", err.Error())
+}
+
+// ArrayLengthEquals — Description
+
+func TestArrayLengthEquals_Description(t *testing.T) {
+	desc := expectations.ArrayLengthEquals[[]int](3).Description()
+	assert.Equal(t, "has length 3", desc)
+}

--- a/internal/expectations/not_test.go
+++ b/internal/expectations/not_test.go
@@ -26,13 +26,13 @@ func TestNot_Description(t *testing.T) {
 }
 
 func TestNot_IsEmpty_FailsOnEmptyString(t *testing.T) {
-	err := expectations.Not(expectations.IsEmpty()).Evaluate("")
+	err := expectations.Not(expectations.IsEmpty[string]()).Evaluate("")
 	require.Error(t, err)
 	assert.Equal(t, "not is empty: got ", err.Error())
 }
 
 func TestNot_IsEmpty_PassesOnNonEmptyString(t *testing.T) {
-	err := expectations.Not(expectations.IsEmpty()).Evaluate("hello")
+	err := expectations.Not(expectations.IsEmpty[string]()).Evaluate("hello")
 	assert.NoError(t, err)
 }
 

--- a/verity_expectations/expectations.go
+++ b/verity_expectations/expectations.go
@@ -7,10 +7,16 @@ import (
 
 var Contains = internalexpectations.Contains
 var ContainsKey = internalexpectations.ContainsKey
-var IsEmpty = internalexpectations.IsEmpty
-var ArrayLengthEquals = internalexpectations.ArrayLengthEquals
 var IsGreaterThan = internalexpectations.IsGreaterThan
 var IsLessThan = internalexpectations.IsLessThan
+
+func IsEmpty[T any]() ensure.Expectation[T] {
+	return internalexpectations.IsEmpty[T]()
+}
+
+func ArrayLengthEquals[T any](expectedLength int) ensure.Expectation[T] {
+	return internalexpectations.ArrayLengthEquals[T](expectedLength)
+}
 
 func Equals[T any](expected T) ensure.Expectation[T] {
 	return internalexpectations.Equals(expected)


### PR DESCRIPTION
IsEmpty and ArrayLengthEquals were typed as Expectation[interface{}], making them incompatible with typed questions (e.g. Question[[]int]). Convert both to generic functions so they work with any slice, string, array, or map type. Update public API wrappers and existing tests.

Fixes #21