### PR TITLE
feat: expectations can accept questions as expected values (issue #34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ TODO.md
 .worktrees/
 
 test_report.txt
+
+.tdd-session/

--- a/internal/expectations/collection.go
+++ b/internal/expectations/collection.go
@@ -1,9 +1,11 @@
 package expectations
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
+	"github.com/verity-bdd/verity-bdd/internal/core"
 	"github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
 )
 
@@ -11,7 +13,7 @@ import (
 type IsEmptyExpectation[T any] struct{}
 
 // Evaluate evaluates the is empty expectation
-func (ie IsEmptyExpectation[T]) Evaluate(actual T) error {
+func (ie IsEmptyExpectation[T]) Evaluate(_ context.Context, _ core.Actor, actual T) error {
 	val := reflect.ValueOf(actual)
 
 	switch val.Kind() {
@@ -50,7 +52,7 @@ type ArrayLengthEqualsExpectation[T any] struct {
 }
 
 // Evaluate evaluates the array length expectation
-func (ale ArrayLengthEqualsExpectation[T]) Evaluate(actual T) error {
+func (ale ArrayLengthEqualsExpectation[T]) Evaluate(_ context.Context, _ core.Actor, actual T) error {
 	val := reflect.ValueOf(actual)
 
 	var length int
@@ -77,4 +79,33 @@ func (ale ArrayLengthEqualsExpectation[T]) Description() string {
 // ArrayLengthEquals creates an ArrayLengthEquals expectation for the given type
 func ArrayLengthEquals[T any](expectedLength int) ensure.Expectation[T] {
 	return ArrayLengthEqualsExpectation[T]{expectedLength: expectedLength}
+}
+
+// ArrayLengthEqualsAnswerToExpectation checks if an array/slice/string has the length equal to the answer of a question
+type ArrayLengthEqualsAnswerToExpectation[T any] struct {
+	question core.Question[int]
+}
+
+// Evaluate answers the question, then delegates to ArrayLengthEqualsExpectation
+func (a ArrayLengthEqualsAnswerToExpectation[T]) Evaluate(ctx context.Context, actor core.Actor, actual T) error {
+	expected, err := a.question.AnsweredBy(ctx, actor)
+	if err != nil {
+		return newQuestionResolutionError(a.question.Description(), err)
+	}
+	return ArrayLengthEqualsExpectation[T]{expectedLength: expected}.Evaluate(ctx, actor, actual)
+}
+
+// Description returns the expectation description
+func (a ArrayLengthEqualsAnswerToExpectation[T]) Description() string {
+	return fmt.Sprintf("has length equal to the answer to '%s'", a.question.Description())
+}
+
+// ArrayLengthEqualsAnswerTo checks if an array/slice/string has the length equal to the answer of the given question.
+// When used in a polling activity (e.g. wait.Until), the expected-value question is
+// re-answered on every poll tick. To use a fixed expected value, resolve the question
+// once and pass the result to ArrayLengthEquals instead.
+// If the expected-value question returns an error on any tick, the poll exits immediately
+// rather than retrying — it does not count as a transient failure.
+func ArrayLengthEqualsAnswerTo[T any](q core.Question[int]) ensure.Expectation[T] {
+	return ArrayLengthEqualsAnswerToExpectation[T]{question: q}
 }

--- a/internal/expectations/collection_test.go
+++ b/internal/expectations/collection_test.go
@@ -1,11 +1,15 @@
 package expectations_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
+	coreMocks "github.com/verity-bdd/verity-bdd/internal/core/testing/mocks"
 	"github.com/verity-bdd/verity-bdd/internal/expectations"
 )
 
@@ -13,13 +17,13 @@ import (
 
 func TestIsEmpty_PassesOnEmptySlice(t *testing.T) {
 	t.Parallel()
-	err := expectations.IsEmpty[[]int]().Evaluate([]int{})
+	err := expectations.IsEmpty[[]int]().Evaluate(context.Background(), nil, []int{})
 	assert.NoError(t, err)
 }
 
 func TestIsEmpty_FailsOnNonEmptySlice(t *testing.T) {
 	t.Parallel()
-	err := expectations.IsEmpty[[]int]().Evaluate([]int{1, 2, 3})
+	err := expectations.IsEmpty[[]int]().Evaluate(context.Background(), nil, []int{1, 2, 3})
 	require.Error(t, err)
 	assert.Equal(t, "expected slice/array to be empty, but got 3 elements", err.Error())
 }
@@ -28,13 +32,13 @@ func TestIsEmpty_FailsOnNonEmptySlice(t *testing.T) {
 
 func TestIsEmpty_PassesOnEmptyString(t *testing.T) {
 	t.Parallel()
-	err := expectations.IsEmpty[string]().Evaluate("")
+	err := expectations.IsEmpty[string]().Evaluate(context.Background(), nil, "")
 	assert.NoError(t, err)
 }
 
 func TestIsEmpty_FailsOnNonEmptyString(t *testing.T) {
 	t.Parallel()
-	err := expectations.IsEmpty[string]().Evaluate("hello")
+	err := expectations.IsEmpty[string]().Evaluate(context.Background(), nil, "hello")
 	require.Error(t, err)
 	assert.Equal(t, "expected string to be empty, but got 'hello'", err.Error())
 }
@@ -43,13 +47,13 @@ func TestIsEmpty_FailsOnNonEmptyString(t *testing.T) {
 
 func TestIsEmpty_PassesOnEmptyMap(t *testing.T) {
 	t.Parallel()
-	err := expectations.IsEmpty[map[string]int]().Evaluate(map[string]int{})
+	err := expectations.IsEmpty[map[string]int]().Evaluate(context.Background(), nil, map[string]int{})
 	assert.NoError(t, err)
 }
 
 func TestIsEmpty_FailsOnNonEmptyMap(t *testing.T) {
 	t.Parallel()
-	err := expectations.IsEmpty[map[string]int]().Evaluate(map[string]int{"a": 1})
+	err := expectations.IsEmpty[map[string]int]().Evaluate(context.Background(), nil, map[string]int{"a": 1})
 	require.Error(t, err)
 	assert.Equal(t, "expected map to be empty, but got 1 elements", err.Error())
 }
@@ -66,13 +70,13 @@ func TestIsEmpty_Description(t *testing.T) {
 
 func TestArrayLengthEquals_PassesOnMatchingSlice(t *testing.T) {
 	t.Parallel()
-	err := expectations.ArrayLengthEquals[[]int](3).Evaluate([]int{1, 2, 3})
+	err := expectations.ArrayLengthEquals[[]int](3).Evaluate(context.Background(), nil, []int{1, 2, 3})
 	assert.NoError(t, err)
 }
 
 func TestArrayLengthEquals_FailsOnWrongLengthSlice(t *testing.T) {
 	t.Parallel()
-	err := expectations.ArrayLengthEquals[[]int](3).Evaluate([]int{1, 2})
+	err := expectations.ArrayLengthEquals[[]int](3).Evaluate(context.Background(), nil, []int{1, 2})
 	require.Error(t, err)
 	assert.Equal(t, "expected length to be 3, but got 2", err.Error())
 }
@@ -81,13 +85,13 @@ func TestArrayLengthEquals_FailsOnWrongLengthSlice(t *testing.T) {
 
 func TestArrayLengthEquals_PassesOnMatchingString(t *testing.T) {
 	t.Parallel()
-	err := expectations.ArrayLengthEquals[string](5).Evaluate("hello")
+	err := expectations.ArrayLengthEquals[string](5).Evaluate(context.Background(), nil, "hello")
 	assert.NoError(t, err)
 }
 
 func TestArrayLengthEquals_FailsOnWrongLengthString(t *testing.T) {
 	t.Parallel()
-	err := expectations.ArrayLengthEquals[string](5).Evaluate("hi")
+	err := expectations.ArrayLengthEquals[string](5).Evaluate(context.Background(), nil, "hi")
 	require.Error(t, err)
 	assert.Equal(t, "expected length to be 5, but got 2", err.Error())
 }
@@ -98,4 +102,40 @@ func TestArrayLengthEquals_Description(t *testing.T) {
 	t.Parallel()
 	desc := expectations.ArrayLengthEquals[[]int](3).Description()
 	assert.Equal(t, "has length 3", desc)
+}
+
+// ArrayLengthEqualsAnswerTo tests
+
+func TestArrayLengthEqualsAnswerTo_PassesWhenQuestionAnswerMatchesLength(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[int](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(3, nil)
+	mockQ.EXPECT().Description().Return("the length").AnyTimes()
+
+	err := expectations.ArrayLengthEqualsAnswerTo[[]string](mockQ).Evaluate(context.Background(), nil, []string{"a", "b", "c"})
+	assert.NoError(t, err)
+}
+
+func TestArrayLengthEqualsAnswerTo_FailsWhenQuestionErrors(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[int](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(0, errors.New("q failed"))
+	mockQ.EXPECT().Description().Return("the length").AnyTimes()
+
+	err := expectations.ArrayLengthEqualsAnswerTo[[]string](mockQ).Evaluate(context.Background(), nil, []string{"a"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "q failed")
+}
+
+func TestArrayLengthEqualsAnswerTo_FailsWhenLengthDoesNotMatch(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[int](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(5, nil)
+	mockQ.EXPECT().Description().Return("the length").AnyTimes()
+
+	err := expectations.ArrayLengthEqualsAnswerTo[[]string](mockQ).Evaluate(context.Background(), nil, []string{"a", "b"})
+	require.Error(t, err)
 }

--- a/internal/expectations/comparison.go
+++ b/internal/expectations/comparison.go
@@ -1,8 +1,10 @@
 package expectations
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/verity-bdd/verity-bdd/internal/core"
 	"github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
 	"github.com/verity-bdd/verity-bdd/internal/expectations/utils"
 )
@@ -18,7 +20,7 @@ func NewIsGreaterThan(expected interface{}) ensure.Expectation[interface{}] {
 }
 
 // Evaluate evaluates the greater than expectation
-func (igt IsGreaterThanExpectation) Evaluate(actual interface{}) error {
+func (igt IsGreaterThanExpectation) Evaluate(_ context.Context, _ core.Actor, actual interface{}) error {
 	return utils.CompareValues(actual, igt.expected, ">")
 }
 
@@ -43,7 +45,7 @@ func NewIsLessThan(expected interface{}) ensure.Expectation[interface{}] {
 }
 
 // Evaluate evaluates the less than expectation
-func (ilt IsLessThanExpectation) Evaluate(actual interface{}) error {
+func (ilt IsLessThanExpectation) Evaluate(_ context.Context, _ core.Actor, actual interface{}) error {
 	return utils.CompareValues(actual, ilt.expected, "<")
 }
 
@@ -55,4 +57,62 @@ func (ilt IsLessThanExpectation) Description() string {
 // Convenience function for creating IsLessThan expectations
 func IsLessThan(expected interface{}) ensure.Expectation[interface{}] {
 	return NewIsLessThan(expected)
+}
+
+// IsGreaterThanAnswerToExpectation checks if a value is greater than the answer to a question
+type IsGreaterThanAnswerToExpectation struct {
+	question core.Question[interface{}]
+}
+
+// Evaluate answers the question, then delegates to IsGreaterThanExpectation
+func (ig IsGreaterThanAnswerToExpectation) Evaluate(ctx context.Context, actor core.Actor, actual interface{}) error {
+	expected, err := ig.question.AnsweredBy(ctx, actor)
+	if err != nil {
+		return newQuestionResolutionError(ig.question.Description(), err)
+	}
+	return IsGreaterThanExpectation{expected: expected}.Evaluate(ctx, actor, actual)
+}
+
+// Description returns the expectation description
+func (ig IsGreaterThanAnswerToExpectation) Description() string {
+	return fmt.Sprintf("is greater than the answer to '%s'", ig.question.Description())
+}
+
+// IsGreaterThanAnswerTo checks if a value is greater than the answer to the given question.
+// When used in a polling activity (e.g. wait.Until), the expected-value question is
+// re-answered on every poll tick. To use a fixed expected value, resolve the question
+// once and pass the result to IsGreaterThan instead.
+// If the expected-value question returns an error on any tick, the poll exits immediately
+// rather than retrying — it does not count as a transient failure.
+func IsGreaterThanAnswerTo(q core.Question[interface{}]) ensure.Expectation[interface{}] {
+	return IsGreaterThanAnswerToExpectation{question: q}
+}
+
+// IsLessThanAnswerToExpectation checks if a value is less than the answer to a question
+type IsLessThanAnswerToExpectation struct {
+	question core.Question[interface{}]
+}
+
+// Evaluate answers the question, then delegates to IsLessThanExpectation
+func (il IsLessThanAnswerToExpectation) Evaluate(ctx context.Context, actor core.Actor, actual interface{}) error {
+	expected, err := il.question.AnsweredBy(ctx, actor)
+	if err != nil {
+		return newQuestionResolutionError(il.question.Description(), err)
+	}
+	return IsLessThanExpectation{expected: expected}.Evaluate(ctx, actor, actual)
+}
+
+// Description returns the expectation description
+func (il IsLessThanAnswerToExpectation) Description() string {
+	return fmt.Sprintf("is less than the answer to '%s'", il.question.Description())
+}
+
+// IsLessThanAnswerTo checks if a value is less than the answer to the given question.
+// When used in a polling activity (e.g. wait.Until), the expected-value question is
+// re-answered on every poll tick. To use a fixed expected value, resolve the question
+// once and pass the result to IsLessThan instead.
+// If the expected-value question returns an error on any tick, the poll exits immediately
+// rather than retrying — it does not count as a transient failure.
+func IsLessThanAnswerTo(q core.Question[interface{}]) ensure.Expectation[interface{}] {
+	return IsLessThanAnswerToExpectation{question: q}
 }

--- a/internal/expectations/comparison_test.go
+++ b/internal/expectations/comparison_test.go
@@ -1,0 +1,82 @@
+package expectations_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	coreMocks "github.com/verity-bdd/verity-bdd/internal/core/testing/mocks"
+	expectations "github.com/verity-bdd/verity-bdd/internal/expectations"
+)
+
+func TestIsGreaterThanAnswerTo_PassesWhenActualExceedsQuestionAnswer(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[interface{}](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(int(5), nil)
+	mockQ.EXPECT().Description().Return("the threshold").AnyTimes()
+
+	err := expectations.IsGreaterThanAnswerTo(mockQ).Evaluate(context.Background(), nil, int(10))
+	assert.NoError(t, err)
+}
+
+func TestIsGreaterThanAnswerTo_FailsWhenQuestionErrors(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[interface{}](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(nil, errors.New("q failed"))
+	mockQ.EXPECT().Description().Return("the threshold").AnyTimes()
+
+	err := expectations.IsGreaterThanAnswerTo(mockQ).Evaluate(context.Background(), nil, int(10))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "q failed")
+}
+
+func TestIsLessThanAnswerTo_PassesWhenActualIsBelowQuestionAnswer(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[interface{}](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(int(10), nil)
+	mockQ.EXPECT().Description().Return("the threshold").AnyTimes()
+
+	err := expectations.IsLessThanAnswerTo(mockQ).Evaluate(context.Background(), nil, int(5))
+	assert.NoError(t, err)
+}
+
+func TestIsLessThanAnswerTo_FailsWhenQuestionErrors(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[interface{}](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(nil, errors.New("q failed"))
+	mockQ.EXPECT().Description().Return("the threshold").AnyTimes()
+
+	err := expectations.IsLessThanAnswerTo(mockQ).Evaluate(context.Background(), nil, int(5))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "q failed")
+}
+
+func TestIsGreaterThanAnswerTo_FailsWhenActualIsNotGreater(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[interface{}](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(int(10), nil)
+	mockQ.EXPECT().Description().Return("the threshold").AnyTimes()
+
+	err := expectations.IsGreaterThanAnswerTo(mockQ).Evaluate(context.Background(), nil, int(5))
+	require.Error(t, err)
+}
+
+func TestIsLessThanAnswerTo_FailsWhenActualIsNotLess(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[interface{}](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(int(5), nil)
+	mockQ.EXPECT().Description().Return("the threshold").AnyTimes()
+
+	err := expectations.IsLessThanAnswerTo(mockQ).Evaluate(context.Background(), nil, int(10))
+	require.Error(t, err)
+}

--- a/internal/expectations/contains.go
+++ b/internal/expectations/contains.go
@@ -1,10 +1,12 @@
 package expectations
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
 
+	"github.com/verity-bdd/verity-bdd/internal/core"
 	"github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
 )
 
@@ -19,7 +21,7 @@ func NewContains(substring string) ensure.Expectation[string] {
 }
 
 // Evaluate evaluates the contains expectation
-func (c ContainsExpectation) Evaluate(actual string) error {
+func (c ContainsExpectation) Evaluate(_ context.Context, _ core.Actor, actual string) error {
 	if actual == "" {
 		return fmt.Errorf("expected string to contain '%s', but got empty string", c.substring)
 	}
@@ -50,7 +52,7 @@ func NewContainsKey(key string) ensure.Expectation[interface{}] {
 }
 
 // Evaluate evaluates the contains key expectation
-func (ck ContainsKeyExpectation) Evaluate(actual interface{}) error {
+func (ck ContainsKeyExpectation) Evaluate(_ context.Context, _ core.Actor, actual interface{}) error {
 	val := reflect.ValueOf(actual)
 	if val.Kind() != reflect.Map {
 		return fmt.Errorf("expected a map, but got %T", actual)
@@ -80,4 +82,62 @@ func (ck ContainsKeyExpectation) Description() string {
 // Convenience function for creating ContainsKey expectations
 func ContainsKey(key string) ensure.Expectation[interface{}] {
 	return NewContainsKey(key)
+}
+
+// ContainsAnswerToExpectation checks if a string contains the answer to a question as a substring
+type ContainsAnswerToExpectation struct {
+	question core.Question[string]
+}
+
+// Evaluate answers the question, then delegates to ContainsExpectation
+func (c ContainsAnswerToExpectation) Evaluate(ctx context.Context, actor core.Actor, actual string) error {
+	expected, err := c.question.AnsweredBy(ctx, actor)
+	if err != nil {
+		return newQuestionResolutionError(c.question.Description(), err)
+	}
+	return ContainsExpectation{substring: expected}.Evaluate(ctx, actor, actual)
+}
+
+// Description returns the expectation description
+func (c ContainsAnswerToExpectation) Description() string {
+	return fmt.Sprintf("contains the answer to '%s'", c.question.Description())
+}
+
+// ContainsAnswerTo checks if a string contains the answer to the given question as a substring.
+// When used in a polling activity (e.g. wait.Until), the expected-value question is
+// re-answered on every poll tick. To use a fixed expected value, resolve the question
+// once and pass the result to Contains instead.
+// If the expected-value question returns an error on any tick, the poll exits immediately
+// rather than retrying — it does not count as a transient failure.
+func ContainsAnswerTo(q core.Question[string]) ensure.Expectation[string] {
+	return ContainsAnswerToExpectation{question: q}
+}
+
+// ContainsKeyAnswerToExpectation checks if a map contains the answer to a question as a key
+type ContainsKeyAnswerToExpectation struct {
+	question core.Question[string]
+}
+
+// Evaluate answers the question, then delegates to ContainsKeyExpectation
+func (c ContainsKeyAnswerToExpectation) Evaluate(ctx context.Context, actor core.Actor, actual interface{}) error {
+	expected, err := c.question.AnsweredBy(ctx, actor)
+	if err != nil {
+		return newQuestionResolutionError(c.question.Description(), err)
+	}
+	return ContainsKeyExpectation{key: expected}.Evaluate(ctx, actor, actual)
+}
+
+// Description returns the expectation description
+func (c ContainsKeyAnswerToExpectation) Description() string {
+	return fmt.Sprintf("contains key from the answer to '%s'", c.question.Description())
+}
+
+// ContainsKeyAnswerTo checks if a map contains the answer to the given question as a key.
+// When used in a polling activity (e.g. wait.Until), the expected-value question is
+// re-answered on every poll tick. To use a fixed expected value, resolve the question
+// once and pass the result to ContainsKey instead.
+// If the expected-value question returns an error on any tick, the poll exits immediately
+// rather than retrying — it does not count as a transient failure.
+func ContainsKeyAnswerTo(q core.Question[string]) ensure.Expectation[interface{}] {
+	return ContainsKeyAnswerToExpectation{question: q}
 }

--- a/internal/expectations/contains_test.go
+++ b/internal/expectations/contains_test.go
@@ -1,0 +1,82 @@
+package expectations_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	coreMocks "github.com/verity-bdd/verity-bdd/internal/core/testing/mocks"
+	"github.com/verity-bdd/verity-bdd/internal/expectations"
+)
+
+func TestContainsAnswerTo_PassesWhenQuestionAnswerMatches(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[string](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return("world", nil)
+	mockQ.EXPECT().Description().Return("the substring").AnyTimes()
+
+	err := expectations.ContainsAnswerTo(mockQ).Evaluate(context.Background(), nil, "hello world")
+	assert.NoError(t, err)
+}
+
+func TestContainsAnswerTo_FailsWhenQuestionErrors(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[string](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return("", errors.New("q failed"))
+	mockQ.EXPECT().Description().Return("the substring").AnyTimes()
+
+	err := expectations.ContainsAnswerTo(mockQ).Evaluate(context.Background(), nil, "hello world")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "q failed")
+}
+
+func TestContainsKeyAnswerTo_PassesWhenQuestionAnswerMatches(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[string](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return("name", nil)
+	mockQ.EXPECT().Description().Return("the key").AnyTimes()
+
+	err := expectations.ContainsKeyAnswerTo(mockQ).Evaluate(context.Background(), nil, map[string]interface{}{"name": "Alice"})
+	assert.NoError(t, err)
+}
+
+func TestContainsKeyAnswerTo_FailsWhenQuestionErrors(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[string](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return("", errors.New("q failed"))
+	mockQ.EXPECT().Description().Return("the key").AnyTimes()
+
+	err := expectations.ContainsKeyAnswerTo(mockQ).Evaluate(context.Background(), nil, map[string]interface{}{"name": "Alice"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "q failed")
+}
+
+func TestContainsAnswerTo_FailsWhenSubstringNotFound(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[string](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return("missing", nil)
+	mockQ.EXPECT().Description().Return("the substring").AnyTimes()
+
+	err := expectations.ContainsAnswerTo(mockQ).Evaluate(context.Background(), nil, "hello world")
+	require.Error(t, err)
+}
+
+func TestContainsKeyAnswerTo_FailsWhenKeyNotFound(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[string](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return("age", nil)
+	mockQ.EXPECT().Description().Return("the key").AnyTimes()
+
+	err := expectations.ContainsKeyAnswerTo(mockQ).Evaluate(context.Background(), nil, map[string]interface{}{"name": "Alice"})
+	require.Error(t, err)
+}

--- a/internal/expectations/ensure/after.go
+++ b/internal/expectations/ensure/after.go
@@ -2,7 +2,6 @@ package ensure
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -34,26 +33,22 @@ func (e *AfterActivity[T]) FailureMode() core.FailureMode {
 }
 
 func (e *AfterActivity[T]) PerformAs(ctx context.Context, actor core.Actor) error {
-	ctx, cancel := context.WithTimeout(ctx, e.duration)
-	defer cancel()
+	timer := time.NewTimer(e.duration)
+	defer timer.Stop()
 
-	<-ctx.Done()
-
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		actual, err := e.question.AnsweredBy(context.Background(), actor)
-		if err != nil {
-			return fmt.Errorf("after waiting %v: question error: %w", e.duration, err)
-		}
-		if evalErr := e.expectation.Evaluate(actual); evalErr != nil {
-			return fmt.Errorf("after waiting %v: assertion failed for '%s': %w",
-				e.duration, e.question.Description(), evalErr)
-		}
-		return nil
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("while waiting for %v: %w", e.duration, ctx.Err())
+	case <-timer.C:
 	}
 
-	if errors.Is(ctx.Err(), context.Canceled) {
-		return fmt.Errorf("while waiting for %v: context canceled", e.duration)
+	actual, err := e.question.AnsweredBy(ctx, actor)
+	if err != nil {
+		return fmt.Errorf("after waiting %v: question error: %w", e.duration, err)
 	}
-
-	return fmt.Errorf("while waiting for %v: %w", e.duration, ctx.Err())
+	if evalErr := e.expectation.Evaluate(ctx, actor, actual); evalErr != nil {
+		return fmt.Errorf("after waiting %v: expectation failed for '%s': %w",
+			e.duration, e.question.Description(), evalErr)
+	}
+	return nil
 }

--- a/internal/expectations/ensure/after_test.go
+++ b/internal/expectations/ensure/after_test.go
@@ -1,0 +1,32 @@
+package ensure_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	coreMocks "github.com/verity-bdd/verity-bdd/internal/core/testing/mocks"
+	"github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
+	"github.com/verity-bdd/verity-bdd/internal/expectations/testhelpers"
+)
+
+func TestAfterActivity_PerformAs_StopsWhenParentContextIsCanceled(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mockQ := coreMocks.NewMockQuestion[int](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Times(0)
+
+	activity := ensure.That(mockQ, &testhelpers.CapturingExpectation[int]{}).
+		After(10 * time.Millisecond)
+
+	err := activity.PerformAs(ctx, nil)
+
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/internal/expectations/ensure/errors.go
+++ b/internal/expectations/ensure/errors.go
@@ -1,0 +1,35 @@
+package ensure
+
+import (
+	"errors"
+	"fmt"
+)
+
+// questionResolutionError is returned by AnswerTo expectations when the expected-value
+// question cannot be answered. Composite expectations (Not, etc.) and polling activities
+// check for this type to distinguish infrastructure failures from value-mismatch failures.
+type questionResolutionError struct {
+	question string
+	err      error
+}
+
+// NewQuestionResolutionError creates an error representing a failure to answer an
+// expected-value question inside an AnswerTo expectation.
+func NewQuestionResolutionError(description string, err error) error {
+	return &questionResolutionError{question: description, err: err}
+}
+
+func (e *questionResolutionError) Error() string {
+	return fmt.Sprintf("failed to answer question '%s': %v", e.question, e.err)
+}
+
+func (e *questionResolutionError) Unwrap() error {
+	return e.err
+}
+
+// IsQuestionResolutionError reports whether err or any error it wraps is a
+// question resolution failure (the expected-value question could not be answered).
+func IsQuestionResolutionError(err error) bool {
+	var qErr *questionResolutionError
+	return errors.As(err, &qErr)
+}

--- a/internal/expectations/ensure/that.go
+++ b/internal/expectations/ensure/that.go
@@ -10,7 +10,7 @@ import (
 // Expectation represents an expectation that can be evaluated against actual values
 type Expectation[T any] interface {
 	// Evaluate evaluates the expectation against the actual value
-	Evaluate(actual T) error
+	Evaluate(ctx context.Context, actor core.Actor, actual T) error
 
 	// Description returns a human-readable description of the expectation
 	Description() string
@@ -45,8 +45,11 @@ func (e *EnsureActivity[T]) PerformAs(ctx context.Context, actor core.Actor) err
 		return fmt.Errorf("failed to answer question '%s': %w", e.question.Description(), err)
 	}
 
-	if evaluateErr := e.expectation.Evaluate(actual); evaluateErr != nil {
-		return fmt.Errorf("assertion failed for '%s': %w", e.question.Description(), evaluateErr)
+	if evaluateErr := e.expectation.Evaluate(ctx, actor, actual); evaluateErr != nil {
+		if IsQuestionResolutionError(evaluateErr) {
+			return evaluateErr
+		}
+		return fmt.Errorf("expectation failed for '%s': %w", e.question.Description(), evaluateErr)
 	}
 
 	return nil

--- a/internal/expectations/ensure/that_test.go
+++ b/internal/expectations/ensure/that_test.go
@@ -1,0 +1,78 @@
+package ensure_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	coreMocks "github.com/verity-bdd/verity-bdd/internal/core/testing/mocks"
+	"github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
+	"github.com/verity-bdd/verity-bdd/internal/expectations/testhelpers"
+)
+
+func TestEnsureActivity_PerformAs_ForwardsCtxAndActor(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "sentinel")
+
+	mockActor := coreMocks.NewMockActor(ctrl)
+	mockQ := coreMocks.NewMockQuestion[int](ctrl)
+	mockQ.EXPECT().AnsweredBy(ctx, mockActor).Return(42, nil)
+	mockQ.EXPECT().Description().Return("the value").AnyTimes()
+
+	inner := &testhelpers.CapturingExpectation[int]{}
+	activity := ensure.That[int](mockQ, inner)
+
+	err := activity.PerformAs(ctx, mockActor)
+	assert.NoError(t, err)
+
+	assert.Equal(t, ctx, inner.CapturedCtx, "ctx should be forwarded unchanged to Evaluate")
+	assert.Equal(t, mockActor, inner.CapturedActor, "actor should be forwarded unchanged to Evaluate")
+}
+
+func TestEnsureActivity_PerformAs_QuestionResolutionError_ReturnedUnwrapped(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+
+	dbErr := errors.New("db error")
+	mockQ := coreMocks.NewMockQuestion[int](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(42, nil)
+	mockQ.EXPECT().Description().Return("outer question").AnyTimes()
+
+	// Expectation that returns a questionResolutionError (simulating an AnswerTo failure).
+	inner := &testhelpers.CapturingExpectation[int]{
+		ReturnErr: ensure.NewQuestionResolutionError("inner question", dbErr),
+	}
+
+	err := ensure.That(mockQ, inner).PerformAs(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.True(t, ensure.IsQuestionResolutionError(err), "questionResolutionError must pass through unwrapped")
+	assert.NotContains(t, err.Error(), "expectation failed", "questionResolutionError must not be wrapped in 'expectation failed for'")
+	assert.Contains(t, err.Error(), "inner question")
+	assert.True(t, errors.Is(err, dbErr), "original cause must be reachable via errors.Is")
+}
+
+func TestEnsureActivity_PerformAs_NormalEvaluationError_WrappedWithContext(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+
+	mockQ := coreMocks.NewMockQuestion[int](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(42, nil)
+	mockQ.EXPECT().Description().Return("outer question").AnyTimes()
+
+	inner := &testhelpers.CapturingExpectation[int]{ReturnErr: errors.New("value mismatch")}
+
+	err := ensure.That(mockQ, inner).PerformAs(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.False(t, ensure.IsQuestionResolutionError(err))
+	assert.Contains(t, err.Error(), "expectation failed")
+	assert.Contains(t, err.Error(), "outer question")
+}

--- a/internal/expectations/equals.go
+++ b/internal/expectations/equals.go
@@ -1,9 +1,11 @@
 package expectations
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
+	"github.com/verity-bdd/verity-bdd/internal/core"
 	"github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
 )
 
@@ -18,7 +20,7 @@ func NewEquals[T any](expected T) ensure.Expectation[T] {
 }
 
 // Evaluate evaluates the equals expectation
-func (eq EqualsExpectation[T]) Evaluate(actual T) error {
+func (eq EqualsExpectation[T]) Evaluate(_ context.Context, _ core.Actor, actual T) error {
 	if !reflect.DeepEqual(actual, eq.expected) {
 		return fmt.Errorf("expected %v, but got %v", eq.expected, actual)
 	}
@@ -33,4 +35,33 @@ func (eq EqualsExpectation[T]) Description() string {
 // Convenience function for creating Equals expectations
 func Equals[T any](expected T) ensure.Expectation[T] {
 	return NewEquals(expected)
+}
+
+// EqualsAnswerToExpectation checks if the actual value equals the answer to a question
+type EqualsAnswerToExpectation[T any] struct {
+	question core.Question[T]
+}
+
+// Evaluate answers the question, then delegates to EqualsExpectation
+func (e EqualsAnswerToExpectation[T]) Evaluate(ctx context.Context, actor core.Actor, actual T) error {
+	expected, err := e.question.AnsweredBy(ctx, actor)
+	if err != nil {
+		return newQuestionResolutionError(e.question.Description(), err)
+	}
+	return EqualsExpectation[T]{expected: expected}.Evaluate(ctx, actor, actual)
+}
+
+// Description returns the expectation description
+func (e EqualsAnswerToExpectation[T]) Description() string {
+	return fmt.Sprintf("equals the answer to '%s'", e.question.Description())
+}
+
+// EqualsAnswerTo checks if the actual value equals the answer to the given question.
+// When used in a polling activity (e.g. wait.Until), the expected-value question is
+// re-answered on every poll tick. To use a fixed expected value, resolve the question
+// once and pass the result to Equals instead.
+// If the expected-value question returns an error on any tick, the poll exits immediately
+// rather than retrying — it does not count as a transient failure.
+func EqualsAnswerTo[T any](q core.Question[T]) ensure.Expectation[T] {
+	return EqualsAnswerToExpectation[T]{question: q}
 }

--- a/internal/expectations/equals_test.go
+++ b/internal/expectations/equals_test.go
@@ -1,0 +1,48 @@
+package expectations_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	coreMocks "github.com/verity-bdd/verity-bdd/internal/core/testing/mocks"
+	"github.com/verity-bdd/verity-bdd/internal/expectations"
+)
+
+func TestEqualsAnswerTo_PassesWhenQuestionAnswerMatches(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[int](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(42, nil)
+	mockQ.EXPECT().Description().Return("the answer").AnyTimes()
+
+	err := expectations.EqualsAnswerTo(mockQ).Evaluate(context.Background(), nil, 42)
+	assert.NoError(t, err)
+}
+
+func TestEqualsAnswerTo_FailsWhenQuestionErrors(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[int](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(0, errors.New("db error"))
+	mockQ.EXPECT().Description().Return("the answer").AnyTimes()
+
+	err := expectations.EqualsAnswerTo(mockQ).Evaluate(context.Background(), nil, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db error")
+}
+
+func TestEqualsAnswerTo_FailsWhenValuesDoNotMatch(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[int](ctrl)
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return(42, nil)
+	mockQ.EXPECT().Description().Return("the answer").AnyTimes()
+
+	err := expectations.EqualsAnswerTo(mockQ).Evaluate(context.Background(), nil, 99)
+	require.Error(t, err)
+}

--- a/internal/expectations/errors.go
+++ b/internal/expectations/errors.go
@@ -1,0 +1,13 @@
+package expectations
+
+import "github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
+
+func newQuestionResolutionError(description string, err error) error {
+	return ensure.NewQuestionResolutionError(description, err)
+}
+
+// IsQuestionResolutionError reports whether err or any error it wraps is a
+// question resolution failure (the expected-value question could not be answered).
+func IsQuestionResolutionError(err error) bool {
+	return ensure.IsQuestionResolutionError(err)
+}

--- a/internal/expectations/not.go
+++ b/internal/expectations/not.go
@@ -1,8 +1,10 @@
 package expectations
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/verity-bdd/verity-bdd/internal/core"
 	"github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
 )
 
@@ -11,10 +13,16 @@ type NotExpectation[T any] struct {
 	inner ensure.Expectation[T]
 }
 
-// Evaluate returns nil if the inner expectation fails, and an error if it passes
-func (n NotExpectation[T]) Evaluate(actual T) error {
-	if err := n.inner.Evaluate(actual); err == nil {
+// Evaluate returns nil if the inner expectation fails, and an error if it passes.
+// Question-resolution errors from AnswerTo expectations are propagated rather than
+// treated as "expectation not met".
+func (n NotExpectation[T]) Evaluate(ctx context.Context, actor core.Actor, actual T) error {
+	err := n.inner.Evaluate(ctx, actor, actual)
+	if err == nil {
 		return fmt.Errorf("not %s: got %v", n.inner.Description(), actual)
+	}
+	if IsQuestionResolutionError(err) {
+		return err
 	}
 	return nil
 }

--- a/internal/expectations/not_test.go
+++ b/internal/expectations/not_test.go
@@ -1,23 +1,28 @@
 package expectations_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
+	coreMocks "github.com/verity-bdd/verity-bdd/internal/core/testing/mocks"
 	"github.com/verity-bdd/verity-bdd/internal/expectations"
+	"github.com/verity-bdd/verity-bdd/internal/expectations/testhelpers"
 )
 
 func TestNot_PassesWhenInnerFails(t *testing.T) {
 	t.Parallel()
-	err := expectations.Not(expectations.Equals("foo")).Evaluate("bar")
+	err := expectations.Not(expectations.Equals("foo")).Evaluate(context.Background(), nil, "bar")
 	assert.NoError(t, err)
 }
 
 func TestNot_FailsWhenInnerPasses(t *testing.T) {
 	t.Parallel()
-	err := expectations.Not(expectations.Equals("foo")).Evaluate("foo")
+	err := expectations.Not(expectations.Equals("foo")).Evaluate(context.Background(), nil, "foo")
 	require.Error(t, err)
 	assert.Equal(t, "not equals foo: got foo", err.Error())
 }
@@ -30,26 +35,55 @@ func TestNot_Description(t *testing.T) {
 
 func TestNot_IsEmpty_FailsOnEmptyString(t *testing.T) {
 	t.Parallel()
-	err := expectations.Not(expectations.IsEmpty[string]()).Evaluate("")
+	err := expectations.Not(expectations.IsEmpty[string]()).Evaluate(context.Background(), nil, "")
 	require.Error(t, err)
 	assert.Equal(t, "not is empty: got ", err.Error())
 }
 
 func TestNot_IsEmpty_PassesOnNonEmptyString(t *testing.T) {
 	t.Parallel()
-	err := expectations.Not(expectations.IsEmpty[string]()).Evaluate("hello")
+	err := expectations.Not(expectations.IsEmpty[string]()).Evaluate(context.Background(), nil, "hello")
 	assert.NoError(t, err)
 }
 
 func TestNot_DoubleNegation_PassesWhenInnerPasses(t *testing.T) {
 	t.Parallel()
-	err := expectations.Not(expectations.Not(expectations.Equals("foo"))).Evaluate("foo")
+	err := expectations.Not(expectations.Not(expectations.Equals("foo"))).Evaluate(context.Background(), nil, "foo")
 	assert.NoError(t, err)
 }
 
 func TestNot_DoubleNegation_FailsWhenInnerFails(t *testing.T) {
 	t.Parallel()
-	err := expectations.Not(expectations.Not(expectations.Equals("foo"))).Evaluate("bar")
+	err := expectations.Not(expectations.Not(expectations.Equals("foo"))).Evaluate(context.Background(), nil, "bar")
 	require.Error(t, err)
 	assert.Equal(t, "not not equals foo: got bar", err.Error())
+}
+
+func TestNot_ForwardsCtxAndActorToInner(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockActor := coreMocks.NewMockActor(ctrl)
+
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "sentinel")
+
+	inner := &testhelpers.CapturingExpectation[string]{ReturnErr: assert.AnError}
+	err := expectations.Not[string](inner).Evaluate(ctx, mockActor, "anything")
+	assert.NoError(t, err) // Not inverts the inner failure
+
+	assert.Equal(t, ctx, inner.CapturedCtx, "ctx should be forwarded unchanged")
+	assert.Equal(t, mockActor, inner.CapturedActor, "actor should be forwarded unchanged")
+}
+
+func TestNot_PropagatesQuestionErrorFromInnerAnswerTo(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockQ := coreMocks.NewMockQuestion[string](ctrl)
+	dbErr := errors.New("db error")
+	mockQ.EXPECT().AnsweredBy(gomock.Any(), gomock.Any()).Return("", dbErr)
+	mockQ.EXPECT().Description().Return("the value").AnyTimes()
+
+	err := expectations.Not(expectations.EqualsAnswerTo(mockQ)).Evaluate(context.Background(), nil, "anything")
+	require.Error(t, err, "Not should propagate question-resolution errors rather than swallowing them")
+	assert.True(t, errors.Is(err, dbErr), "propagated error should wrap the original question error")
 }

--- a/internal/expectations/satisfies.go
+++ b/internal/expectations/satisfies.go
@@ -1,6 +1,9 @@
 package expectations
 
 import (
+	"context"
+
+	"github.com/verity-bdd/verity-bdd/internal/core"
 	"github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
 )
 
@@ -32,11 +35,35 @@ func Satisfies[T any](description string, fn func(T) error) ensure.Expectation[T
 }
 
 // Evaluate evaluates the expectation by calling the provided function
-func (s *SatisfiesExpectation[T]) Evaluate(actual T) error {
+func (s *SatisfiesExpectation[T]) Evaluate(_ context.Context, _ core.Actor, actual T) error {
 	return s.fn(actual)
 }
 
 // Description returns the custom description of the expectation
 func (s *SatisfiesExpectation[T]) Description() string {
+	return s.description
+}
+
+// SatisfiesAnswerExpectation represents a custom expectation whose fn receives ctx and actor
+type SatisfiesAnswerExpectation[T any] struct {
+	description string
+	fn          func(context.Context, core.Actor, T) error
+}
+
+// SatisfiesAnswer creates a custom expectation where the fn receives ctx and actor at evaluation time
+func SatisfiesAnswer[T any](description string, fn func(context.Context, core.Actor, T) error) ensure.Expectation[T] {
+	return &SatisfiesAnswerExpectation[T]{
+		description: description,
+		fn:          fn,
+	}
+}
+
+// Evaluate calls the provided function with ctx, actor, and actual
+func (s *SatisfiesAnswerExpectation[T]) Evaluate(ctx context.Context, actor core.Actor, actual T) error {
+	return s.fn(ctx, actor, actual)
+}
+
+// Description returns the custom description of the expectation
+func (s *SatisfiesAnswerExpectation[T]) Description() string {
 	return s.description
 }

--- a/internal/expectations/satisfies_test.go
+++ b/internal/expectations/satisfies_test.go
@@ -1,0 +1,60 @@
+package expectations_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/verity-bdd/verity-bdd/internal/core"
+	coreMocks "github.com/verity-bdd/verity-bdd/internal/core/testing/mocks"
+	"github.com/verity-bdd/verity-bdd/internal/expectations"
+)
+
+func TestSatisfiesAnswer_PassesWhenPredicateReturnsNil(t *testing.T) {
+	t.Parallel()
+	err := expectations.SatisfiesAnswer[int]("is positive", func(_ context.Context, _ core.Actor, actual int) error {
+		if actual > 0 {
+			return nil
+		}
+		return errors.New("not positive")
+	}).Evaluate(context.Background(), nil, 42)
+	assert.NoError(t, err)
+}
+
+func TestSatisfiesAnswer_FailsWhenPredicateReturnsError(t *testing.T) {
+	t.Parallel()
+	err := expectations.SatisfiesAnswer[int]("is positive", func(_ context.Context, _ core.Actor, actual int) error {
+		if actual > 0 {
+			return nil
+		}
+		return errors.New("not positive")
+	}).Evaluate(context.Background(), nil, -1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not positive")
+}
+
+func TestSatisfiesAnswer_ForwardsCtxAndActorToFn(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockActor := coreMocks.NewMockActor(ctrl)
+
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "sentinel")
+
+	var capturedCtx context.Context
+	var capturedActor core.Actor
+
+	err := expectations.SatisfiesAnswer[int]("capturing", func(c context.Context, a core.Actor, _ int) error {
+		capturedCtx = c
+		capturedActor = a
+		return nil
+	}).Evaluate(ctx, mockActor, 0)
+
+	assert.NoError(t, err)
+	assert.Equal(t, ctx, capturedCtx, "ctx should be forwarded unchanged to fn")
+	assert.Equal(t, mockActor, capturedActor, "actor should be forwarded unchanged to fn")
+}

--- a/internal/expectations/testhelpers/testhelpers.go
+++ b/internal/expectations/testhelpers/testhelpers.go
@@ -1,0 +1,28 @@
+package testhelpers
+
+import (
+	"context"
+
+	"github.com/verity-bdd/verity-bdd/internal/core"
+	"github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
+)
+
+// CapturingExpectation records the ctx and actor passed to Evaluate.
+// ReturnErr controls the result: nil means pass, non-nil means fail.
+type CapturingExpectation[T any] struct {
+	CapturedCtx   context.Context
+	CapturedActor core.Actor
+	ReturnErr     error
+}
+
+func (c *CapturingExpectation[T]) Evaluate(ctx context.Context, actor core.Actor, _ T) error {
+	c.CapturedCtx = ctx
+	c.CapturedActor = actor
+	return c.ReturnErr
+}
+
+func (c *CapturingExpectation[T]) Description() string {
+	return "capturing"
+}
+
+var _ ensure.Expectation[int] = (*CapturingExpectation[int])(nil)

--- a/internal/wait/condition.go
+++ b/internal/wait/condition.go
@@ -68,8 +68,18 @@ func (c *ConditionActivity[T]) PerformAs(ctx context.Context, actor core.Actor) 
 		actual, err := c.question.AnsweredBy(ctx, actor)
 		if err != nil {
 			lastErr = err
-		} else if evalErr := c.expectation.Evaluate(actual); evalErr != nil {
-			lastErr = evalErr
+		} else if evalErr := c.expectation.Evaluate(ctx, actor, actual); evalErr != nil {
+			if ensure.IsQuestionResolutionError(evalErr) {
+				if ctx.Err() == nil {
+					return evalErr
+				}
+				// The inner question failed because the context expired during evaluation.
+				// Store the context error so the select produces the correct timeout/cancel
+				// message rather than surfacing a question-resolution error.
+				lastErr = ctx.Err()
+			} else {
+				lastErr = evalErr
+			}
 		} else {
 			return nil
 		}

--- a/internal/wait/condition_test.go
+++ b/internal/wait/condition_test.go
@@ -256,6 +256,101 @@ func TestUntil_IntervalExceedsTimeout(t *testing.T) {
 	}
 }
 
+func TestUntil_AnswerToExpectation_SucceedsAndReevaluatesPerTick(t *testing.T) {
+	t.Parallel()
+	// outerQ returns "bar" on the first poll, then "foo" on subsequent polls.
+	outerQ := &sequenceQuestion[string]{values: []string{"bar", "foo"}}
+	// innerQ (the expected value) always returns "foo".
+	innerQ := &sequenceQuestion[string]{values: []string{"foo"}}
+
+	activity := wait.Until(outerQ, expectations.EqualsAnswerTo(innerQ)).
+		CheckingEvery(1 * time.Millisecond)
+
+	err := activity.PerformAs(context.Background(), &stubActor{})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if outerQ.idx != 2 {
+		t.Fatalf("expected 2 outer polls (1 miss + 1 hit), got %d", outerQ.idx)
+	}
+	// innerQ is re-answered on every poll tick — once per outer poll.
+	if innerQ.idx != 2 {
+		t.Fatalf("expected 2 inner polls (re-evaluated per tick), got %d", innerQ.idx)
+	}
+}
+
+func TestUntil_AnswerToExpectation_FailsFastWhenInnerQuestionErrors(t *testing.T) {
+	t.Parallel()
+	brokenQ := &errorThenValueQuestion[string]{errCount: 999, value: "never"}
+
+	// Use a long timeout; the call must return well before it fires.
+	activity := wait.Until(
+		&sequenceQuestion[string]{values: []string{"anything"}},
+		expectations.EqualsAnswerTo(brokenQ),
+	).For(30 * time.Second).CheckingEvery(1 * time.Millisecond)
+
+	start := time.Now()
+	err := activity.PerformAs(context.Background(), &stubActor{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("expected fast failure, but took %v", elapsed)
+	}
+	if !expectations.IsQuestionResolutionError(err) {
+		t.Errorf("expected a question resolution error, got: %v", err)
+	}
+}
+
+// ctxCheckingQuestion returns ctx.Err() if the context is already done, value otherwise.
+// Used to simulate a well-behaved question that respects context cancellation.
+type ctxCheckingQuestion[T any] struct {
+	value T
+}
+
+func (q *ctxCheckingQuestion[T]) AnsweredBy(ctx context.Context, _ core.Actor) (T, error) {
+	if err := ctx.Err(); err != nil {
+		var zero T
+		return zero, err
+	}
+	return q.value, nil
+}
+
+func (q *ctxCheckingQuestion[T]) Description() string { return "ctx-checking question" }
+
+func TestUntil_AnswerToExpectation_ExpiredCtxProducesTimeoutNotQuestionResolutionError(t *testing.T) {
+	t.Parallel()
+	// outerQ ignores ctx and always returns a value — simulates a synchronous question
+	// that can succeed even after the context deadline has passed.
+	outerQ := &sequenceQuestion[string]{values: []string{"anything"}}
+	// innerQ is ctx-aware: returns ctx.Err() when the context is already done.
+	innerQ := &ctxCheckingQuestion[string]{value: "target"}
+
+	// Pre-cancel the context so the deadline race is deterministic: outerQ succeeds
+	// (ignores ctx), then innerQ fails with context.Canceled. That error must NOT be
+	// treated as a questionResolutionError — it must flow to the select and produce
+	// the correct "context canceled" message.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := wait.Until(outerQ, expectations.EqualsAnswerTo(innerQ)).
+		For(5*time.Second).
+		PerformAs(ctx, &stubActor{})
+
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if expectations.IsQuestionResolutionError(err) {
+		t.Errorf("expired-context error should not surface as a question resolution error; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "canceled") {
+		t.Errorf("expected 'canceled' in error message, got: %v", err)
+	}
+}
+
 func TestUntil_FailureMode(t *testing.T) {
 	t.Parallel()
 	q := &sequenceQuestion[int]{values: []int{0}}

--- a/verity_expectations/api_contract_test.go
+++ b/verity_expectations/api_contract_test.go
@@ -1,8 +1,11 @@
 package verity_expectations_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	verity "github.com/verity-bdd/verity-bdd"
 	answerable "github.com/verity-bdd/verity-bdd/verity_answerable"
 	ve "github.com/verity-bdd/verity-bdd/verity_expectations"
 	"github.com/verity-bdd/verity-bdd/verity_expectations/ensure"
@@ -18,4 +21,24 @@ func TestNotExpectationAPIContractCompiles(t *testing.T) {
 	t.Parallel()
 	q := answerable.ValueOf("hello")
 	_ = ensure.That(q, ve.Not(ve.Contains("xyz")))
+}
+
+func TestAnswerToFactoriesAPIContractCompiles(t *testing.T) {
+	t.Parallel()
+	strQ := answerable.ValueOf("world")
+	intQ := answerable.ValueOf(42)
+	ifaceQ := answerable.ValueOf[interface{}](int(5))
+
+	_ = ensure.That(answerable.ValueOf("hello world"), ve.ContainsAnswerTo(strQ))
+	_ = ensure.That(answerable.ValueOf[interface{}](map[string]interface{}{"name": "Alice"}), ve.ContainsKeyAnswerTo(strQ))
+	_ = ensure.That(answerable.ValueOf(42), ve.EqualsAnswerTo(intQ))
+	_ = ensure.That(answerable.ValueOf([]string{"a", "b"}), ve.ArrayLengthEqualsAnswerTo[[]string](answerable.ValueOf(2)))
+	_ = ensure.That(answerable.ValueOf[interface{}](int(10)), ve.IsGreaterThanAnswerTo(ifaceQ))
+	_ = ensure.That(answerable.ValueOf[interface{}](int(2)), ve.IsLessThanAnswerTo(ifaceQ))
+	_ = ensure.That(answerable.ValueOf(42), ve.SatisfiesAnswer[int]("is positive", func(_ context.Context, _ verity.Actor, actual int) error {
+		if actual > 0 {
+			return nil
+		}
+		return errors.New("not positive")
+	}))
 }

--- a/verity_expectations/ensure/that.go
+++ b/verity_expectations/ensure/that.go
@@ -1,22 +1,27 @@
 package ensure
 
 import (
+	"context"
 	"time"
 
 	verity "github.com/verity-bdd/verity-bdd"
 	internalensure "github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
 )
 
+// Expectation[T] is a condition that can be evaluated against an actual value of type T.
 type Expectation[T any] interface {
-	Evaluate(actual T) error
+	// Evaluate checks whether actual satisfies the expectation.
+	Evaluate(ctx context.Context, actor verity.Actor, actual T) error
 	Description() string
 }
 
+// EnsureThat[T] is the activity returned by That; it supports an optional wait via After.
 type EnsureThat[T any] interface {
 	verity.Activity
 	After(duration time.Duration) verity.Activity
 }
 
+// That creates an activity that asserts the question's answer meets the expectation.
 func That[T any](question verity.Question[T], expectation Expectation[T]) EnsureThat[T] {
 	return internalensure.That(question, expectation)
 }

--- a/verity_expectations/expectations.go
+++ b/verity_expectations/expectations.go
@@ -1,6 +1,9 @@
 package verity_expectations
 
 import (
+	"context"
+
+	verity "github.com/verity-bdd/verity-bdd"
 	internalexpectations "github.com/verity-bdd/verity-bdd/internal/expectations"
 	"github.com/verity-bdd/verity-bdd/verity_expectations/ensure"
 )
@@ -53,4 +56,39 @@ func Satisfies[T any](description string, fn func(T) error) ensure.Expectation[T
 // Not wraps an expectation and inverts its result.
 func Not[T any](inner ensure.Expectation[T]) ensure.Expectation[T] {
 	return internalexpectations.Not(inner)
+}
+
+// EqualsAnswerTo checks if the actual value equals the answer to the given question.
+func EqualsAnswerTo[T any](q verity.Question[T]) ensure.Expectation[T] {
+	return internalexpectations.EqualsAnswerTo(q)
+}
+
+// ContainsAnswerTo checks if a string contains the answer to the given question as a substring.
+func ContainsAnswerTo(q verity.Question[string]) ensure.Expectation[string] {
+	return internalexpectations.ContainsAnswerTo(q)
+}
+
+// ContainsKeyAnswerTo checks if a map contains the answer to the given question as a key.
+func ContainsKeyAnswerTo(q verity.Question[string]) ensure.Expectation[interface{}] {
+	return internalexpectations.ContainsKeyAnswerTo(q)
+}
+
+// ArrayLengthEqualsAnswerTo checks if an array, slice, or string has the length equal to the answer of the given question.
+func ArrayLengthEqualsAnswerTo[T any](q verity.Question[int]) ensure.Expectation[T] {
+	return internalexpectations.ArrayLengthEqualsAnswerTo[T](q)
+}
+
+// IsGreaterThanAnswerTo checks if a value is greater than the answer to the given question.
+func IsGreaterThanAnswerTo(q verity.Question[interface{}]) ensure.Expectation[interface{}] {
+	return internalexpectations.IsGreaterThanAnswerTo(q)
+}
+
+// IsLessThanAnswerTo checks if a value is less than the answer to the given question.
+func IsLessThanAnswerTo(q verity.Question[interface{}]) ensure.Expectation[interface{}] {
+	return internalexpectations.IsLessThanAnswerTo(q)
+}
+
+// SatisfiesAnswer creates a custom expectation where the fn receives ctx and actor at evaluation time.
+func SatisfiesAnswer[T any](description string, fn func(context.Context, verity.Actor, T) error) ensure.Expectation[T] {
+	return internalexpectations.SatisfiesAnswer(description, fn)
 }


### PR DESCRIPTION
Extended Expectation[T].Evaluate to receive ctx and actor alongside the actual value, enabling expectations to answer a Question[T] at evaluation time rather than being limited to static expected values.

Added seven *AnswerTo factories that accept a Question[T] in place of a concrete expected value and resolve it via AnsweredBy during evaluation:

  - EqualsAnswerTo[T]
  - ContainsAnswerTo
  - ContainsKeyAnswerTo
  - ArrayLengthEqualsAnswerTo[T]
  - IsGreaterThanAnswerTo
  - IsLessThanAnswerTo
  - SatisfiesAnswerTo[T] — fn receives ctx and actor directly

Existing factories (Equals, Contains, etc.) are unchanged: they accept static values and ignore the new ctx/actor params in Evaluate.

All seven factories are re-exported from verity_expectations.

Resolves #34