### PR TITLE
fix: retry transient AnswerTo inner-question errors in wait.Until (is…

### DIFF
--- a/internal/expectations/collection.go
+++ b/internal/expectations/collection.go
@@ -104,8 +104,6 @@ func (a ArrayLengthEqualsAnswerToExpectation[T]) Description() string {
 // When used in a polling activity (e.g. wait.Until), the expected-value question is
 // re-answered on every poll tick. To use a fixed expected value, resolve the question
 // once and pass the result to ArrayLengthEquals instead.
-// If the expected-value question returns an error on any tick, the poll exits immediately
-// rather than retrying — it does not count as a transient failure.
 func ArrayLengthEqualsAnswerTo[T any](q core.Question[int]) ensure.Expectation[T] {
 	return ArrayLengthEqualsAnswerToExpectation[T]{question: q}
 }

--- a/internal/expectations/comparison.go
+++ b/internal/expectations/comparison.go
@@ -82,8 +82,6 @@ func (ig IsGreaterThanAnswerToExpectation) Description() string {
 // When used in a polling activity (e.g. wait.Until), the expected-value question is
 // re-answered on every poll tick. To use a fixed expected value, resolve the question
 // once and pass the result to IsGreaterThan instead.
-// If the expected-value question returns an error on any tick, the poll exits immediately
-// rather than retrying — it does not count as a transient failure.
 func IsGreaterThanAnswerTo(q core.Question[interface{}]) ensure.Expectation[interface{}] {
 	return IsGreaterThanAnswerToExpectation{question: q}
 }
@@ -111,8 +109,6 @@ func (il IsLessThanAnswerToExpectation) Description() string {
 // When used in a polling activity (e.g. wait.Until), the expected-value question is
 // re-answered on every poll tick. To use a fixed expected value, resolve the question
 // once and pass the result to IsLessThan instead.
-// If the expected-value question returns an error on any tick, the poll exits immediately
-// rather than retrying — it does not count as a transient failure.
 func IsLessThanAnswerTo(q core.Question[interface{}]) ensure.Expectation[interface{}] {
 	return IsLessThanAnswerToExpectation{question: q}
 }

--- a/internal/expectations/contains.go
+++ b/internal/expectations/contains.go
@@ -107,8 +107,6 @@ func (c ContainsAnswerToExpectation) Description() string {
 // When used in a polling activity (e.g. wait.Until), the expected-value question is
 // re-answered on every poll tick. To use a fixed expected value, resolve the question
 // once and pass the result to Contains instead.
-// If the expected-value question returns an error on any tick, the poll exits immediately
-// rather than retrying — it does not count as a transient failure.
 func ContainsAnswerTo(q core.Question[string]) ensure.Expectation[string] {
 	return ContainsAnswerToExpectation{question: q}
 }
@@ -136,8 +134,6 @@ func (c ContainsKeyAnswerToExpectation) Description() string {
 // When used in a polling activity (e.g. wait.Until), the expected-value question is
 // re-answered on every poll tick. To use a fixed expected value, resolve the question
 // once and pass the result to ContainsKey instead.
-// If the expected-value question returns an error on any tick, the poll exits immediately
-// rather than retrying — it does not count as a transient failure.
 func ContainsKeyAnswerTo(q core.Question[string]) ensure.Expectation[interface{}] {
 	return ContainsKeyAnswerToExpectation{question: q}
 }

--- a/internal/expectations/ensure/that_test.go
+++ b/internal/expectations/ensure/that_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	coreMocks "github.com/verity-bdd/verity-bdd/internal/core/testing/mocks"
+	"github.com/verity-bdd/verity-bdd/internal/expectations"
 	"github.com/verity-bdd/verity-bdd/internal/expectations/ensure"
 	"github.com/verity-bdd/verity-bdd/internal/expectations/testhelpers"
 )
@@ -75,4 +76,44 @@ func TestEnsureActivity_PerformAs_NormalEvaluationError_WrappedWithContext(t *te
 	assert.False(t, ensure.IsQuestionResolutionError(err))
 	assert.Contains(t, err.Error(), "expectation failed")
 	assert.Contains(t, err.Error(), "outer question")
+}
+
+func TestEnsureActivity_PerformAs_EqualsAnswerTo_InnerQuestionError_ReturnsQuestionResolutionError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	outerQ := coreMocks.NewMockQuestion[string](ctrl)
+	outerQ.EXPECT().AnsweredBy(ctx, nil).Return("x", nil)
+	outerQ.EXPECT().Description().Return("outer question").AnyTimes()
+
+	innerQ := coreMocks.NewMockQuestion[string](ctrl)
+	innerQ.EXPECT().AnsweredBy(ctx, nil).Return("", errors.New("db error"))
+	innerQ.EXPECT().Description().Return("inner question").AnyTimes()
+
+	err := ensure.That[string](outerQ, expectations.EqualsAnswerTo(innerQ)).PerformAs(ctx, nil)
+
+	require.Error(t, err)
+	assert.True(t, ensure.IsQuestionResolutionError(err), "expected questionResolutionError, got: %v", err)
+}
+
+func TestEnsureActivity_PerformAs_NotEqualsAnswerTo_InnerQuestionError_PropagatesQuestionResolutionError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	outerQ := coreMocks.NewMockQuestion[string](ctrl)
+	outerQ.EXPECT().AnsweredBy(ctx, nil).Return("x", nil)
+	outerQ.EXPECT().Description().Return("outer question").AnyTimes()
+
+	innerQ := coreMocks.NewMockQuestion[string](ctrl)
+	innerQ.EXPECT().AnsweredBy(ctx, nil).Return("", errors.New("db error"))
+	innerQ.EXPECT().Description().Return("inner question").AnyTimes()
+
+	err := ensure.That[string](outerQ, expectations.Not(expectations.EqualsAnswerTo(innerQ))).PerformAs(ctx, nil)
+
+	require.Error(t, err)
+	assert.True(t, ensure.IsQuestionResolutionError(err), "expected questionResolutionError, got: %v", err)
 }

--- a/internal/expectations/equals.go
+++ b/internal/expectations/equals.go
@@ -60,8 +60,6 @@ func (e EqualsAnswerToExpectation[T]) Description() string {
 // When used in a polling activity (e.g. wait.Until), the expected-value question is
 // re-answered on every poll tick. To use a fixed expected value, resolve the question
 // once and pass the result to Equals instead.
-// If the expected-value question returns an error on any tick, the poll exits immediately
-// rather than retrying — it does not count as a transient failure.
 func EqualsAnswerTo[T any](q core.Question[T]) ensure.Expectation[T] {
 	return EqualsAnswerToExpectation[T]{question: q}
 }

--- a/internal/wait/condition.go
+++ b/internal/wait/condition.go
@@ -69,17 +69,7 @@ func (c *ConditionActivity[T]) PerformAs(ctx context.Context, actor core.Actor) 
 		if err != nil {
 			lastErr = err
 		} else if evalErr := c.expectation.Evaluate(ctx, actor, actual); evalErr != nil {
-			if ensure.IsQuestionResolutionError(evalErr) {
-				if ctx.Err() == nil {
-					return evalErr
-				}
-				// The inner question failed because the context expired during evaluation.
-				// Store the context error so the select produces the correct timeout/cancel
-				// message rather than surfacing a question-resolution error.
-				lastErr = ctx.Err()
-			} else {
-				lastErr = evalErr
-			}
+			lastErr = evalErr
 		} else {
 			return nil
 		}

--- a/internal/wait/condition_test.go
+++ b/internal/wait/condition_test.go
@@ -280,31 +280,6 @@ func TestUntil_AnswerToExpectation_SucceedsAndReevaluatesPerTick(t *testing.T) {
 	}
 }
 
-func TestUntil_AnswerToExpectation_FailsFastWhenInnerQuestionErrors(t *testing.T) {
-	t.Parallel()
-	brokenQ := &errorThenValueQuestion[string]{errCount: 999, value: "never"}
-
-	// Use a long timeout; the call must return well before it fires.
-	activity := wait.Until(
-		&sequenceQuestion[string]{values: []string{"anything"}},
-		expectations.EqualsAnswerTo(brokenQ),
-	).For(30 * time.Second).CheckingEvery(1 * time.Millisecond)
-
-	start := time.Now()
-	err := activity.PerformAs(context.Background(), &stubActor{})
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("expected an error, got nil")
-	}
-	if elapsed > time.Second {
-		t.Fatalf("expected fast failure, but took %v", elapsed)
-	}
-	if !expectations.IsQuestionResolutionError(err) {
-		t.Errorf("expected a question resolution error, got: %v", err)
-	}
-}
-
 // ctxCheckingQuestion returns ctx.Err() if the context is already done, value otherwise.
 // Used to simulate a well-behaved question that respects context cancellation.
 type ctxCheckingQuestion[T any] struct {
@@ -321,7 +296,7 @@ func (q *ctxCheckingQuestion[T]) AnsweredBy(ctx context.Context, _ core.Actor) (
 
 func (q *ctxCheckingQuestion[T]) Description() string { return "ctx-checking question" }
 
-func TestUntil_AnswerToExpectation_ExpiredCtxProducesTimeoutNotQuestionResolutionError(t *testing.T) {
+func TestUntil_AnswerToExpectation_ExpiredCtxProducesCanceledError(t *testing.T) {
 	t.Parallel()
 	// outerQ ignores ctx and always returns a value — simulates a synchronous question
 	// that can succeed even after the context deadline has passed.
@@ -330,9 +305,9 @@ func TestUntil_AnswerToExpectation_ExpiredCtxProducesTimeoutNotQuestionResolutio
 	innerQ := &ctxCheckingQuestion[string]{value: "target"}
 
 	// Pre-cancel the context so the deadline race is deterministic: outerQ succeeds
-	// (ignores ctx), then innerQ fails with context.Canceled. That error must NOT be
-	// treated as a questionResolutionError — it must flow to the select and produce
-	// the correct "context canceled" message.
+	// (ignores ctx), then innerQ returns context.Canceled. That error flows to the
+	// select branch in the wait loop, which surfaces it as the "context canceled"
+	// message rather than a transient poll failure.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -343,11 +318,28 @@ func TestUntil_AnswerToExpectation_ExpiredCtxProducesTimeoutNotQuestionResolutio
 	if err == nil {
 		t.Fatal("expected an error, got nil")
 	}
-	if expectations.IsQuestionResolutionError(err) {
-		t.Errorf("expired-context error should not surface as a question resolution error; got: %v", err)
-	}
 	if !strings.Contains(err.Error(), "canceled") {
 		t.Errorf("expected 'canceled' in error message, got: %v", err)
+	}
+}
+
+func TestUntil_AnswerToExpectation_PreCanceledCtxProducesCanceledError(t *testing.T) {
+	t.Parallel()
+	outerQ := &sequenceQuestion[string]{values: []string{"anything"}}
+	innerQ := &ctxCheckingQuestion[string]{value: "target"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := wait.Until(outerQ, expectations.EqualsAnswerTo(innerQ)).
+		For(5*time.Second).
+		PerformAs(ctx, &stubActor{})
+
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "canceled") {
+		t.Fatalf("expected 'canceled' in error message, got: %v", err)
 	}
 }
 
@@ -358,5 +350,144 @@ func TestUntil_FailureMode(t *testing.T) {
 
 	if mode := activity.FailureMode(); mode != core.FailFast {
 		t.Fatalf("expected FailFast, got %v", mode)
+	}
+}
+
+func TestUntil_AnswerToExpectation_RetriesOnTransientInnerQuestionError(t *testing.T) {
+	t.Parallel()
+	outerQ := &sequenceQuestion[string]{values: []string{"target"}}
+	innerQ := &errorThenValueQuestion[string]{errCount: 3, value: "target"}
+
+	activity := wait.Until(outerQ, expectations.EqualsAnswerTo(innerQ)).
+		CheckingEvery(1 * time.Millisecond)
+
+	err := activity.PerformAs(context.Background(), &stubActor{})
+
+	if err != nil {
+		t.Fatalf("expected no error after transient inner question errors, got %v", err)
+	}
+}
+
+func TestUntil_AnswerToExpectation_TimesOutWhenInnerQuestionAlwaysErrors(t *testing.T) {
+	t.Parallel()
+	outerQ := &sequenceQuestion[string]{values: []string{"anything"}}
+	innerQ := &errorThenValueQuestion[string]{errCount: 999, value: "never"}
+
+	start := time.Now()
+	err := wait.Until(outerQ, expectations.EqualsAnswerTo(innerQ)).
+		For(50*time.Millisecond).
+		CheckingEvery(1*time.Millisecond).
+		PerformAs(context.Background(), &stubActor{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected error to contain \"timed out\", got: %v", err)
+	}
+	if elapsed < 50*time.Millisecond {
+		t.Fatalf("expected elapsed time >= 50ms (did not fast-fail), got: %v", elapsed)
+	}
+}
+
+func TestUntil_AnswerToExpectation_TimeoutErrorContainsInnerQuestionErrorText(t *testing.T) {
+	t.Parallel()
+	outerQ := &sequenceQuestion[string]{values: []string{"anything"}}
+	innerQ := &errorThenValueQuestion[string]{errCount: 999, value: "never"}
+
+	err := wait.Until(outerQ, expectations.EqualsAnswerTo(innerQ)).
+		For(50*time.Millisecond).
+		CheckingEvery(1*time.Millisecond).
+		PerformAs(context.Background(), &stubActor{})
+
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not ready yet") {
+		t.Fatalf("expected timeout error to contain inner question error text \"not ready yet\", got: %v", err)
+	}
+}
+
+func TestUntil_NotEqualsAnswerTo_RetriesOnTransientInnerQuestionError(t *testing.T) {
+	t.Parallel()
+	outerQ := &sequenceQuestion[string]{values: []string{"target"}}
+	innerQ := &errorThenValueQuestion[string]{errCount: 3, value: "other"}
+
+	activity := wait.Until(outerQ, expectations.Not(expectations.EqualsAnswerTo(innerQ))).
+		CheckingEvery(1 * time.Millisecond)
+
+	err := activity.PerformAs(context.Background(), &stubActor{})
+
+	if err != nil {
+		t.Fatalf("expected no error after transient inner question errors, got %v", err)
+	}
+}
+
+func TestUntil_NotEqualsAnswerTo_TimesOutWhenInnerQuestionAlwaysErrors(t *testing.T) {
+	t.Parallel()
+	outerQ := &sequenceQuestion[string]{values: []string{"anything"}}
+	innerQ := &errorThenValueQuestion[string]{errCount: 999, value: "never"}
+
+	start := time.Now()
+	err := wait.Until(outerQ, expectations.Not(expectations.EqualsAnswerTo(innerQ))).
+		For(50*time.Millisecond).
+		CheckingEvery(1*time.Millisecond).
+		PerformAs(context.Background(), &stubActor{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected error to contain \"timed out\", got: %v", err)
+	}
+	if elapsed < 50*time.Millisecond {
+		t.Fatalf("expected elapsed time >= 50ms (did not fast-fail), got: %v", elapsed)
+	}
+}
+
+func TestUntil_ContainsAnswerTo_RetriesOnTransientInnerQuestionError(t *testing.T) {
+	t.Parallel()
+	outerQ := &sequenceQuestion[string]{values: []string{"hello world"}}
+	innerQ := &errorThenValueQuestion[string]{errCount: 2, value: "world"}
+
+	activity := wait.Until(outerQ, expectations.ContainsAnswerTo(innerQ)).
+		CheckingEvery(1 * time.Millisecond)
+
+	err := activity.PerformAs(context.Background(), &stubActor{})
+
+	if err != nil {
+		t.Fatalf("expected no error after transient inner question errors, got %v", err)
+	}
+}
+
+func TestUntil_IsGreaterThanAnswerTo_RetriesOnTransientInnerQuestionError(t *testing.T) {
+	t.Parallel()
+	outerQ := &sequenceQuestion[interface{}]{values: []interface{}{int(10)}}
+	innerQ := &errorThenValueQuestion[interface{}]{errCount: 2, value: int(5)}
+
+	activity := wait.Until(outerQ, expectations.IsGreaterThanAnswerTo(innerQ)).
+		CheckingEvery(1 * time.Millisecond)
+
+	err := activity.PerformAs(context.Background(), &stubActor{})
+
+	if err != nil {
+		t.Fatalf("expected no error after transient inner question errors, got %v", err)
+	}
+}
+
+func TestUntil_ArrayLengthEqualsAnswerTo_RetriesOnTransientInnerQuestionError(t *testing.T) {
+	t.Parallel()
+	outerQ := &sequenceQuestion[[]string]{values: [][]string{{"a", "b", "c"}}}
+	innerQ := &errorThenValueQuestion[int]{errCount: 2, value: 3}
+
+	activity := wait.Until(outerQ, expectations.ArrayLengthEqualsAnswerTo[[]string](innerQ)).
+		CheckingEvery(1 * time.Millisecond)
+
+	err := activity.PerformAs(context.Background(), &stubActor{})
+
+	if err != nil {
+		t.Fatalf("expected no error after transient inner question errors, got %v", err)
 	}
 }

--- a/internal/wait/condition_test.go
+++ b/internal/wait/condition_test.go
@@ -323,26 +323,6 @@ func TestUntil_AnswerToExpectation_ExpiredCtxProducesCanceledError(t *testing.T)
 	}
 }
 
-func TestUntil_AnswerToExpectation_PreCanceledCtxProducesCanceledError(t *testing.T) {
-	t.Parallel()
-	outerQ := &sequenceQuestion[string]{values: []string{"anything"}}
-	innerQ := &ctxCheckingQuestion[string]{value: "target"}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	err := wait.Until(outerQ, expectations.EqualsAnswerTo(innerQ)).
-		For(5*time.Second).
-		PerformAs(ctx, &stubActor{})
-
-	if err == nil {
-		t.Fatal("expected an error, got nil")
-	}
-	if !strings.Contains(err.Error(), "canceled") {
-		t.Fatalf("expected 'canceled' in error message, got: %v", err)
-	}
-}
-
 func TestUntil_FailureMode(t *testing.T) {
 	t.Parallel()
 	q := &sequenceQuestion[int]{values: []int{0}}
@@ -483,6 +463,36 @@ func TestUntil_ArrayLengthEqualsAnswerTo_RetriesOnTransientInnerQuestionError(t 
 	innerQ := &errorThenValueQuestion[int]{errCount: 2, value: 3}
 
 	activity := wait.Until(outerQ, expectations.ArrayLengthEqualsAnswerTo[[]string](innerQ)).
+		CheckingEvery(1 * time.Millisecond)
+
+	err := activity.PerformAs(context.Background(), &stubActor{})
+
+	if err != nil {
+		t.Fatalf("expected no error after transient inner question errors, got %v", err)
+	}
+}
+
+func TestUntil_IsLessThanAnswerTo_RetriesOnTransientInnerQuestionError(t *testing.T) {
+	t.Parallel()
+	outerQ := &sequenceQuestion[interface{}]{values: []interface{}{int(3)}}
+	innerQ := &errorThenValueQuestion[interface{}]{errCount: 2, value: int(10)}
+
+	activity := wait.Until(outerQ, expectations.IsLessThanAnswerTo(innerQ)).
+		CheckingEvery(1 * time.Millisecond)
+
+	err := activity.PerformAs(context.Background(), &stubActor{})
+
+	if err != nil {
+		t.Fatalf("expected no error after transient inner question errors, got %v", err)
+	}
+}
+
+func TestUntil_ContainsKeyAnswerTo_RetriesOnTransientInnerQuestionError(t *testing.T) {
+	t.Parallel()
+	outerQ := &sequenceQuestion[interface{}]{values: []interface{}{map[string]interface{}{"foo": 1}}}
+	innerQ := &errorThenValueQuestion[string]{errCount: 2, value: "foo"}
+
+	activity := wait.Until(outerQ, expectations.ContainsKeyAnswerTo(innerQ)).
 		CheckingEvery(1 * time.Millisecond)
 
 	err := activity.PerformAs(context.Background(), &stubActor{})


### PR DESCRIPTION
…sue #36)

Previously, when an *AnswerTo expectation (EqualsAnswerTo, ContainsAnswerTo, etc.) could not resolve its expected-value question, wait.Until exited immediately rather than retrying on the next tick. This was too aggressive for transient failures such as a momentarily unreachable database or a slow cache fallback.

The fast-fail block is removed from ConditionActivity.PerformAs: question-resolution errors are now treated as ordinary poll failures, stored as lastErr, and retried until the timeout. If all ticks fail, the timeout error wraps the last inner error.

Adds regression tests covering retry-on-transient, timeout-on-persistent, and canceled-context paths for all AnswerTo expectation variants. Also adds characterization tests confirming that ensure.That (single-shot) still surfaces question-resolution errors unchanged.

Resolves #36