### PR TITLE
fix: expose last response body JSON question

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ err := actor.AttemptsTo(
     ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
 
     // Parse response as JSON struct
-    ensure.That(api.NewResponseBodyAsJSON[User](), expectations.Satisfies("has valid user", func(actual User) error {
+    ensure.That(api.LastResponseBodyAsJSON[User](), expectations.Satisfies("has valid user", func(actual User) error {
         if actual.Name == "" {
             return fmt.Errorf("user name is empty")
         }

--- a/verity_abilities/api/api.go
+++ b/verity_abilities/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	verity "github.com/verity-bdd/verity-bdd"
 	internalapi "github.com/verity-bdd/verity-bdd/internal/abilities/api"
 )
 
@@ -62,8 +63,8 @@ var NewResponseHeader = internalapi.NewResponseHeader
 // NewJSONPath creates a new question that extracts the value at the given JSON path from the last HTTP response body.
 var NewJSONPath = internalapi.NewJSONPath
 
-// NewResponseBodyAsJSON creates a new question that parses the last HTTP response body as JSON into type T.
-func NewResponseBodyAsJSON[T any]() internalapi.ResponseBodyAsJSON[T] {
+// LastResponseBodyAsJSON creates a question that parses the last HTTP response body as JSON into type T.
+func LastResponseBodyAsJSON[T any]() verity.Question[T] {
 	return internalapi.NewResponseBodyAsJSON[T]()
 }
 

--- a/verity_abilities/api/public_api_test.go
+++ b/verity_abilities/api/public_api_test.go
@@ -1,0 +1,60 @@
+package api_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestExportedFunctionSignaturesDoNotExposeInternalPackages(t *testing.T) {
+	t.Parallel()
+
+	fileset := token.NewFileSet()
+	file, err := parser.ParseFile(fileset, "api.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse public API: %v", err)
+	}
+
+	imports := make(map[string]string, len(file.Imports))
+	for _, spec := range file.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			t.Fatalf("unquote import path %s: %v", spec.Path.Value, err)
+		}
+
+		name := path.Base(importPath)
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+		imports[name] = importPath
+	}
+
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || !ast.IsExported(function.Name.Name) {
+			continue
+		}
+
+		ast.Inspect(function.Type, func(node ast.Node) bool {
+			selector, ok := node.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+
+			packageName, ok := selector.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+
+			importPath, ok := imports[packageName.Name]
+			if ok && strings.Contains(importPath, "/internal/") {
+				t.Errorf("%s exposes internal type %s.%s", function.Name.Name, packageName.Name, selector.Sel.Name)
+			}
+			return true
+		})
+	}
+}

--- a/verity_abilities/api/public_api_test.go
+++ b/verity_abilities/api/public_api_test.go
@@ -4,57 +4,153 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 )
 
+func TestFindInternalTypeLeaks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		files     map[string]string
+		wantLeaks int
+	}{
+		{
+			name: "checks every production Go file",
+			files: map[string]string{
+				"api.go": "package api\n",
+				"questions.go": `package api
+
+import internalapi "example.com/project/internal/api"
+
+func LeakedQuestion() internalapi.Question { return internalapi.Question{} }
+`,
+			},
+			wantLeaks: 1,
+		},
+		{
+			name: "recognizes internal package root",
+			files: map[string]string{
+				"api.go": `package api
+
+import internalapi "example.com/project/internal"
+
+func LeakedQuestion() internalapi.Question { return internalapi.Question{} }
+`,
+			},
+			wantLeaks: 1,
+		},
+		{
+			name: "ignores test files",
+			files: map[string]string{
+				"api.go": "package api\n",
+				"questions_test.go": `package api_test
+
+import internalapi "example.com/project/internal/api"
+
+func LeakedTestHelper() internalapi.Question { return internalapi.Question{} }
+`,
+			},
+			wantLeaks: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			directory := t.TempDir()
+			for name, source := range test.files {
+				writeGoFile(t, directory, name, source)
+			}
+
+			leaks, err := findInternalTypeLeaks(directory)
+			if err != nil {
+				t.Fatalf("find internal type leaks: %v", err)
+			}
+			if len(leaks) != test.wantLeaks {
+				t.Fatalf("expected %d internal type leaks, got %v", test.wantLeaks, leaks)
+			}
+		})
+	}
+}
+
+func writeGoFile(t *testing.T, directory, name, source string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(directory, name), []byte(source), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func findInternalTypeLeaks(directory string) ([]string, error) {
+	fileset := token.NewFileSet()
+	packages, err := parser.ParseDir(fileset, directory, func(info os.FileInfo) bool {
+		return !strings.HasSuffix(info.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var leaks []string
+	for _, pkg := range packages {
+		for _, file := range pkg.Files {
+			imports := make(map[string]string, len(file.Imports))
+			for _, spec := range file.Imports {
+				importPath, err := strconv.Unquote(spec.Path.Value)
+				if err != nil {
+					return nil, err
+				}
+
+				name := path.Base(importPath)
+				if spec.Name != nil {
+					name = spec.Name.Name
+				}
+				imports[name] = importPath
+			}
+
+			for _, declaration := range file.Decls {
+				function, ok := declaration.(*ast.FuncDecl)
+				if !ok || !ast.IsExported(function.Name.Name) {
+					continue
+				}
+
+				ast.Inspect(function.Type, func(node ast.Node) bool {
+					selector, ok := node.(*ast.SelectorExpr)
+					if !ok {
+						return true
+					}
+
+					packageName, ok := selector.X.(*ast.Ident)
+					if !ok {
+						return true
+					}
+
+					importPath, ok := imports[packageName.Name]
+					if ok && (strings.Contains(importPath, "/internal/") || strings.HasSuffix(importPath, "/internal")) {
+						leaks = append(leaks, function.Name.Name+" exposes internal type "+packageName.Name+"."+selector.Sel.Name)
+					}
+					return true
+				})
+			}
+		}
+	}
+
+	return leaks, nil
+}
+
 func TestExportedFunctionSignaturesDoNotExposeInternalPackages(t *testing.T) {
 	t.Parallel()
 
-	fileset := token.NewFileSet()
-	file, err := parser.ParseFile(fileset, "api.go", nil, 0)
+	leaks, err := findInternalTypeLeaks(".")
 	if err != nil {
-		t.Fatalf("parse public API: %v", err)
+		t.Fatalf("find internal type leaks: %v", err)
 	}
-
-	imports := make(map[string]string, len(file.Imports))
-	for _, spec := range file.Imports {
-		importPath, err := strconv.Unquote(spec.Path.Value)
-		if err != nil {
-			t.Fatalf("unquote import path %s: %v", spec.Path.Value, err)
-		}
-
-		name := path.Base(importPath)
-		if spec.Name != nil {
-			name = spec.Name.Name
-		}
-		imports[name] = importPath
-	}
-
-	for _, declaration := range file.Decls {
-		function, ok := declaration.(*ast.FuncDecl)
-		if !ok || !ast.IsExported(function.Name.Name) {
-			continue
-		}
-
-		ast.Inspect(function.Type, func(node ast.Node) bool {
-			selector, ok := node.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-
-			packageName, ok := selector.X.(*ast.Ident)
-			if !ok {
-				return true
-			}
-
-			importPath, ok := imports[packageName.Name]
-			if ok && strings.Contains(importPath, "/internal/") {
-				t.Errorf("%s exposes internal type %s.%s", function.Name.Name, packageName.Name, selector.Sel.Name)
-			}
-			return true
-		})
+	for _, leak := range leaks {
+		t.Error(leak)
 	}
 }

--- a/verity_abilities/api_contract_test.go
+++ b/verity_abilities/api_contract_test.go
@@ -11,9 +11,16 @@ import (
 	ve "github.com/verity-bdd/verity-bdd/verity_expectations"
 )
 
+type apiResponse struct {
+	Message string `json:"message"`
+}
+
+func requireQuestion[T any](question verity.Question[T]) {}
+
 func TestAbilitiesAPIContractCompiles(t *testing.T) {
 	t.Parallel()
 	var _ verity.Ability = api.CallAnApiAt("https://example.com")
+	requireQuestion[apiResponse](api.LastResponseBodyAsJSON[apiResponse]())
 
 	notebook := take_notes.NewNoteBook()
 	_ = take_notes.Using(notebook)


### PR DESCRIPTION
## Summary

Fixes the remaining internal-type leak in the public API response question.

### Changes

- Rename the public factory:
  - `api.NewResponseBodyAsJSON[T]()` → `api.LastResponseBodyAsJSON[T]()`
- Return the public `verity.Question[T]` contract instead of `internalapi.ResponseBodyAsJSON[T]`.
- Update the README example to use the final public name.
- Add a consumer-facing compile contract for `verity.Question[T]`.
- Add a source-policy test that rejects `internal/*` types in exported function signatures in `verity_abilities/api`.

The internal JSON decoding behavior is unchanged.

## Breaking change

This removes the old pre-v1 public name:

```go
api.NewResponseBodyAsJSON[T]()
```

Use:

```go
api.LastResponseBodyAsJSON[T]()
```

## Verification

- `go test ./... -count=1` ✅
- `go test -race ./... -count=1` ✅
- `go vet ./...` ✅
- `go mod tidy -diff` ✅
- `golangci-lint v2.8.0 run --timeout=5m` ✅
- Independent pre-commit review ✅

Resolves #29