### PR TITLE
feat(testing): expose registered actor snapshots

### DIFF
--- a/api_contract_root_test.go
+++ b/api_contract_root_test.go
@@ -20,4 +20,8 @@ func TestRootAPIContractCompiles(t *testing.T) {
 	})
 
 	_, _ = q.AnsweredBy(context.Background(), nil)
+
+	test := verity.NewVerityTest(t, verity.Scene{})
+	var actors []verity.Actor = test.Actors() //nolint:staticcheck // Explicitly verifies the public return type.
+	_ = actors
 }

--- a/docs/adr/0001-actor-registry-snapshots.md
+++ b/docs/adr/0001-actor-registry-snapshots.md
@@ -16,7 +16,9 @@ Consumers need to inspect the actors registered by a `VerityTest` without gainin
 
 Add `Actors() []Actor` to `VerityTest`.
 
-Each call acquires the registry read lock and checks the test lifecycle state under that lock. After `Shutdown`, it returns a non-nil empty slice regardless of any later `ActorCalled` calls. Otherwise, it copies all registered actor references into a new non-nil slice, sorts that slice by `Actor.Name()` in ascending case-sensitive lexical order, and returns it. The map's existing name key preserves one actor per repeated `ActorCalled` name. `Shutdown` also clears the registry.
+Each call copies all registered actor references into a new non-nil slice while holding the registry read lock, releases the lock, sorts the independent slice by `Actor.Name()` in ascending case-sensitive lexical order, and returns it. The map's existing name key preserves one actor per repeated `ActorCalled` name.
+
+`Shutdown` is a terminal, idempotent lifecycle transition. Under the same lock used by `ActorCalled`, it finishes reporting, sets the actor registry to `nil`, and marks the test shut down. `ActorCalled` uses one write-lock critical section for lookup and creation; after shutdown it explicitly panics with `verity: ActorCalled called after Shutdown`. Consequently an `ActorCalled` racing `Shutdown` either completes before the terminal transition or acquires the lock afterward and panics. `Actors` needs no shutdown-specific branch: after shutdown, copying the nil registry naturally produces a non-nil empty snapshot.
 
 ## Rejected alternatives
 
@@ -24,7 +26,8 @@ Each call acquires the registry read lock and checks the test lifecycle state un
 - Return a cached slice: allows caller mutations to affect later results and complicates synchronization.
 - Return actor copies: breaks actor identity and would require copying actor-owned synchronized state.
 - Preserve registration order: requires additional state solely for inspection and conflicts with deterministic name ordering.
+- Mask post-shutdown registrations in `Actors`: lets `ActorCalled` create hidden actors after the terminal transition and makes the snapshot misrepresent the registry. Reject post-shutdown mutation at `ActorCalled` instead.
 
 ## Consequences
 
-Callers receive deterministic, isolated slice snapshots containing the original actor instances. Snapshot creation costs one allocation plus sorting, and holds a read lock while copying and sorting; actor registration and shutdown wait briefly for that lock.
+Callers receive deterministic, isolated slice snapshots containing the original actor instances. Snapshot creation costs one allocation plus sorting, but holds the read lock only while copying; sorting cannot block actor registration or shutdown. Shutdown releases registry-held actor references, and lifecycle misuse fails explicitly rather than creating hidden state.

--- a/docs/adr/0001-actor-registry-snapshots.md
+++ b/docs/adr/0001-actor-registry-snapshots.md
@@ -1,0 +1,30 @@
+# ADR 0001: Expose actor registry snapshots
+
+## Status
+
+Accepted
+
+## Convention
+
+Architecture decisions live in `docs/adr` and use `NNNN-kebab-case-title.md`, with numbers assigned sequentially starting at `0001`.
+
+## Context
+
+Consumers need to inspect the actors registered by a `VerityTest` without gaining access to, or depending on, its mutable internal registry. The registry is shared with concurrent `ActorCalled` and `Shutdown` operations.
+
+## Decision
+
+Add `Actors() []Actor` to `VerityTest`.
+
+Each call acquires the registry read lock and checks the test lifecycle state under that lock. After `Shutdown`, it returns a non-nil empty slice regardless of any later `ActorCalled` calls. Otherwise, it copies all registered actor references into a new non-nil slice, sorts that slice by `Actor.Name()` in ascending case-sensitive lexical order, and returns it. The map's existing name key preserves one actor per repeated `ActorCalled` name. `Shutdown` also clears the registry.
+
+## Rejected alternatives
+
+- Return the registry map: exposes mutable internal state and map iteration order.
+- Return a cached slice: allows caller mutations to affect later results and complicates synchronization.
+- Return actor copies: breaks actor identity and would require copying actor-owned synchronized state.
+- Preserve registration order: requires additional state solely for inspection and conflicts with deterministic name ordering.
+
+## Consequences
+
+Callers receive deterministic, isolated slice snapshots containing the original actor instances. Snapshot creation costs one allocation plus sorting, and holds a read lock while copying and sorting; actor registration and shutdown wait briefly for that lock.

--- a/internal/testing/verity_test_manager.go
+++ b/internal/testing/verity_test_manager.go
@@ -61,15 +61,21 @@ type VerityTest interface {
 	//
 	// Returns:
 	//	An Actor instance configured for automatic error handling
+	//
+	// ActorCalled panics with "verity: ActorCalled called after Shutdown" when
+	// invoked after Shutdown has made the test lifecycle terminal.
 	ActorCalled(name string) core.Actor
 
 	// Actors returns a fresh, non-nil snapshot of the registered actors, sorted
 	// by Name in ascending case-sensitive lexical order. The snapshot contains
 	// the original actor instances; modifying the slice does not change the
-	// registry. After Shutdown, Actors returns an empty snapshot.
+	// registry. Shutdown clears the registry, so subsequent calls return an empty
+	// snapshot.
 	Actors() []core.Actor
 
-	// Shutdown cleans up resources and finalizes the test.
+	// Shutdown cleans up resources and terminally finalizes the test. It is
+	// idempotent; after it returns, ActorCalled panics and Actors returns an empty
+	// snapshot.
 	// This method should be called via defer after creating the test instance.
 	// Failure to call Shutdown() may result in resource leaks.
 	//
@@ -223,18 +229,13 @@ func NewVerityTestWithReporter(ctx context.Context, t TestContext, reporter repo
 
 // ActorCalled returns an actor with the given name
 func (st *verityTest) ActorCalled(name string) core.Actor {
-	st.mutex.RLock()
-	actor, exists := st.actors[name]
-	st.mutex.RUnlock()
-
-	if exists {
-		return actor
-	}
-
 	st.mutex.Lock()
 	defer st.mutex.Unlock()
 
-	// Double-check after acquiring write lock
+	if st.shutdown {
+		panic("verity: ActorCalled called after Shutdown")
+	}
+
 	if actor, exists := st.actors[name]; exists {
 		return actor
 	}
@@ -260,25 +261,19 @@ func (st *verityTest) ActorCalled(name string) core.Actor {
 		createdActor.WhoCan(ability)
 	}
 
-	actor = createdActor
-
-	st.actors[name] = actor
-	return actor
+	st.actors[name] = createdActor
+	return createdActor
 }
 
 // Actors returns a snapshot of the actors registered with this test.
 func (st *verityTest) Actors() []core.Actor {
 	st.mutex.RLock()
-	defer st.mutex.RUnlock()
-
-	if st.shutdown {
-		return make([]core.Actor, 0)
-	}
-
 	actors := make([]core.Actor, 0, len(st.actors))
 	for _, actor := range st.actors {
 		actors = append(actors, actor)
 	}
+	st.mutex.RUnlock()
+
 	sort.Slice(actors, func(i, j int) bool {
 		return actors[i].Name() < actors[j].Name()
 	})
@@ -346,8 +341,8 @@ func (st *verityTest) Shutdown() {
 		st.adapter.GetReporter().OnTestFinish(result)
 	}
 
-	// Clear actors map
-	st.actors = make(map[string]core.Actor)
+	// Release actor references and make the lifecycle terminal.
+	st.actors = nil
 	st.shutdown = true
 }
 

--- a/internal/testing/verity_test_manager.go
+++ b/internal/testing/verity_test_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -61,6 +62,12 @@ type VerityTest interface {
 	// Returns:
 	//	An Actor instance configured for automatic error handling
 	ActorCalled(name string) core.Actor
+
+	// Actors returns a fresh, non-nil snapshot of the registered actors, sorted
+	// by Name in ascending case-sensitive lexical order. The snapshot contains
+	// the original actor instances; modifying the slice does not change the
+	// registry. After Shutdown, Actors returns an empty snapshot.
+	Actors() []core.Actor
 
 	// Shutdown cleans up resources and finalizes the test.
 	// This method should be called via defer after creating the test instance.
@@ -257,6 +264,25 @@ func (st *verityTest) ActorCalled(name string) core.Actor {
 
 	st.actors[name] = actor
 	return actor
+}
+
+// Actors returns a snapshot of the actors registered with this test.
+func (st *verityTest) Actors() []core.Actor {
+	st.mutex.RLock()
+	defer st.mutex.RUnlock()
+
+	if st.shutdown {
+		return make([]core.Actor, 0)
+	}
+
+	actors := make([]core.Actor, 0, len(st.actors))
+	for _, actor := range st.actors {
+		actors = append(actors, actor)
+	}
+	sort.Slice(actors, func(i, j int) bool {
+		return actors[i].Name() < actors[j].Name()
+	})
+	return actors
 }
 
 // TestContext returns the embedded testing.TB interface.

--- a/internal/testing/verity_test_manager_test.go
+++ b/internal/testing/verity_test_manager_test.go
@@ -3,12 +3,15 @@ package testing
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/verity-bdd/verity-bdd/internal/abilities"
+	"github.com/verity-bdd/verity-bdd/internal/core"
 	"github.com/verity-bdd/verity-bdd/internal/reporting"
 	"github.com/verity-bdd/verity-bdd/internal/reporting/console_reporter"
 	reportingMocks "github.com/verity-bdd/verity-bdd/internal/reporting/mocks"
@@ -324,4 +327,223 @@ func TestNewVerityNames(t *testing.T) {
 
 	withReporter := NewVerityTestWithReporter(ctx, t, console_reporter.NewConsoleReporter())
 	require.NotNil(t, withReporter)
+}
+
+func TestVerityTestActors_EmptySnapshotIsNonNil(t *testing.T) {
+	t.Parallel()
+	test := NewVerityTest(t, Scene{})
+
+	actors := test.Actors()
+
+	require.NotNil(t, actors)
+	require.Empty(t, actors)
+}
+
+func TestVerityTestActors_IncludesEveryRegisteredActorInstance(t *testing.T) {
+	t.Parallel()
+	test := NewVerityTest(t, Scene{})
+	emptyName := test.ActorCalled("")
+	alice := test.ActorCalled("Alice")
+
+	actors := test.Actors()
+
+	require.Len(t, actors, 2)
+	require.Contains(t, actors, emptyName)
+	require.Contains(t, actors, alice)
+	require.Same(t, emptyName, actors[0])
+	require.Same(t, alice, actors[1])
+}
+
+func TestVerityTestActors_SortsUniqueActorsByCaseSensitiveName(t *testing.T) {
+	t.Parallel()
+	test := NewVerityTest(t, Scene{})
+	bob := test.ActorCalled("bob")
+	aliceUpper := test.ActorCalled("Alice")
+	aliceLower := test.ActorCalled("alice")
+	require.Same(t, aliceUpper, test.ActorCalled("Alice"))
+
+	actors := test.Actors()
+
+	require.Len(t, actors, 3)
+	require.Equal(t, []string{"Alice", "alice", "bob"}, []string{actors[0].Name(), actors[1].Name(), actors[2].Name()})
+	require.Same(t, aliceUpper, actors[0])
+	require.Same(t, aliceLower, actors[1])
+	require.Same(t, bob, actors[2])
+}
+
+func TestVerityTestActors_ReturnsFreshSliceSnapshots(t *testing.T) {
+	t.Parallel()
+	test := NewVerityTest(t, Scene{})
+	alice := test.ActorCalled("Alice")
+	bob := test.ActorCalled("Bob")
+
+	first := test.Actors()
+	first[0] = bob
+	mutated := append(first, alice)
+
+	require.Len(t, mutated, 3)
+	require.Equal(t, []core.Actor{alice, bob}, test.Actors())
+}
+
+func TestVerityTestActors_IsNonNilAndEmptyAfterShutdown(t *testing.T) {
+	t.Parallel()
+	test := NewVerityTest(t, Scene{})
+	test.ActorCalled("Alice")
+	test.Shutdown()
+
+	actors := test.Actors()
+
+	require.NotNil(t, actors)
+	require.Empty(t, actors)
+}
+
+func TestVerityTestActors_RemainsEmptyWhenActorCalledAfterShutdown(t *testing.T) {
+	t.Parallel()
+	test := NewVerityTest(t, Scene{})
+	test.Shutdown()
+	test.ActorCalled("Alice")
+
+	actors := test.Actors()
+
+	require.NotNil(t, actors)
+	require.Empty(t, actors)
+}
+
+func TestVerityTestActors_ConcurrentSnapshotsAreConsistent(t *testing.T) {
+	t.Parallel()
+	test := NewVerityTest(t, Scene{})
+	const actorCount = 64
+	const registrationsPerActor = 4
+	const readers = 8
+
+	start := make(chan struct{})
+	done := make(chan struct{})
+	errs := make(chan error, readers)
+
+	var readerWG sync.WaitGroup
+	for range readers {
+		readerWG.Add(1)
+		go func() {
+			defer readerWG.Done()
+			<-start
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+
+				actors := test.Actors()
+				if actors == nil {
+					errs <- fmt.Errorf("Actors returned a nil snapshot")
+					return
+				}
+				for i, actor := range actors {
+					if actor == nil {
+						errs <- fmt.Errorf("snapshot contains a nil actor at index %d", i)
+						return
+					}
+					if i > 0 && actors[i-1].Name() >= actor.Name() {
+						errs <- fmt.Errorf("snapshot is not strictly sorted: %q before %q", actors[i-1].Name(), actor.Name())
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	var writerWG sync.WaitGroup
+	for i := range actorCount * registrationsPerActor {
+		writerWG.Add(1)
+		go func() {
+			defer writerWG.Done()
+			<-start
+			test.ActorCalled(fmt.Sprintf("Actor-%02d", i%actorCount))
+		}()
+	}
+
+	close(start)
+	writerWG.Wait()
+	close(done)
+	readerWG.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	actors := test.Actors()
+	require.Len(t, actors, actorCount)
+	for i, actor := range actors {
+		require.Equal(t, fmt.Sprintf("Actor-%02d", i), actor.Name())
+	}
+}
+
+func TestVerityTestActors_ConcurrentWithShutdownReturnsAtomicSnapshots(t *testing.T) {
+	t.Parallel()
+	test := NewVerityTest(t, Scene{})
+	const actorCount = 64
+	const readers = 32
+	const snapshotsPerReader = 256
+
+	expected := make([]core.Actor, actorCount)
+	for i := actorCount - 1; i >= 0; i-- {
+		expected[i] = test.ActorCalled(fmt.Sprintf("Actor-%02d", i))
+	}
+
+	var ready sync.WaitGroup
+	ready.Add(readers + 1)
+	start := make(chan struct{})
+	errCh := make(chan error, readers)
+
+	var readersWG sync.WaitGroup
+	for range readers {
+		readersWG.Add(1)
+		go func() {
+			defer readersWG.Done()
+			ready.Done()
+			<-start
+
+			for range snapshotsPerReader {
+				actors := test.Actors()
+				if actors == nil {
+					errCh <- fmt.Errorf("Actors returned a nil snapshot")
+					return
+				}
+				if len(actors) == 0 {
+					continue
+				}
+				if len(actors) != len(expected) {
+					errCh <- fmt.Errorf("snapshot contains %d actors, want either 0 or %d", len(actors), len(expected))
+					return
+				}
+				for i, actor := range actors {
+					if actor != expected[i] {
+						errCh <- fmt.Errorf("snapshot actor %d is not the original sorted instance for %q", i, expected[i].Name())
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		ready.Done()
+		<-start
+		test.Shutdown()
+		close(shutdownDone)
+	}()
+
+	ready.Wait()
+	close(start)
+	readersWG.Wait()
+	<-shutdownDone
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	actors := test.Actors()
+	require.NotNil(t, actors)
+	require.Empty(t, actors)
 }

--- a/internal/testing/verity_test_manager_test.go
+++ b/internal/testing/verity_test_manager_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,6 +25,22 @@ import (
 type sceneDefaultAbility struct {
 	owner string
 }
+
+type countingReporter struct {
+	finishCount atomic.Int64
+}
+
+func (*countingReporter) OnTestStart(string) {}
+
+func (r *countingReporter) OnTestFinish(reporting.TestResult) {
+	r.finishCount.Add(1)
+}
+
+func (*countingReporter) OnStepStart(string) {}
+
+func (*countingReporter) OnStepFinish(reporting.TestResult) {}
+
+func (*countingReporter) SetOutput(io.Writer) {}
 
 func TestNewVerityTest_ConfiguredByScene(t *testing.T) {
 	t.Parallel()
@@ -385,7 +403,7 @@ func TestVerityTestActors_ReturnsFreshSliceSnapshots(t *testing.T) {
 	require.Equal(t, []core.Actor{alice, bob}, test.Actors())
 }
 
-func TestVerityTestActors_IsNonNilAndEmptyAfterShutdown(t *testing.T) {
+func TestVerityTestActors_ShutdownReleasesRegistryAndReturnsNonNilEmptySnapshot(t *testing.T) {
 	t.Parallel()
 	test := NewVerityTest(t, Scene{})
 	test.ActorCalled("Alice")
@@ -393,20 +411,139 @@ func TestVerityTestActors_IsNonNilAndEmptyAfterShutdown(t *testing.T) {
 
 	actors := test.Actors()
 
+	require.Nil(t, test.(*verityTest).actors)
 	require.NotNil(t, actors)
 	require.Empty(t, actors)
 }
 
-func TestVerityTestActors_RemainsEmptyWhenActorCalledAfterShutdown(t *testing.T) {
+func TestVerityTestActorCalled_CompletedBeforeShutdownRemainsLegal(t *testing.T) {
+	t.Parallel()
+	test := NewVerityTest(t, Scene{})
+
+	alice := test.ActorCalled("Alice")
+	test.Shutdown()
+
+	require.Equal(t, "Alice", alice.Name())
+	require.Empty(t, test.Actors())
+}
+
+func TestVerityTestActorCalled_PanicsAfterShutdown(t *testing.T) {
 	t.Parallel()
 	test := NewVerityTest(t, Scene{})
 	test.Shutdown()
+
+	require.PanicsWithValue(t, "verity: ActorCalled called after Shutdown", func() {
+		test.ActorCalled("Alice")
+	})
+}
+
+func TestVerityTestActorCalled_ConcurrentWithShutdownLinearizesAtTerminalState(t *testing.T) {
+	t.Parallel()
+	const attempts = 256
+
+	type actorCallResult struct {
+		actor      core.Actor
+		panicValue any
+	}
+
+	for range attempts {
+		reporter := &countingReporter{}
+		test := NewVerityTest(t, Scene{Reporter: reporter})
+		concrete := test.(*verityTest)
+
+		var ready sync.WaitGroup
+		ready.Add(2)
+		start := make(chan struct{})
+		actorResult := make(chan actorCallResult, 1)
+		shutdownPanic := make(chan any, 1)
+
+		go func() {
+			result := actorCallResult{}
+			defer func() {
+				result.panicValue = recover()
+				actorResult <- result
+			}()
+			ready.Done()
+			<-start
+			result.actor = test.ActorCalled("Alice")
+		}()
+
+		go func() {
+			var panicValue any
+			defer func() {
+				panicValue = recover()
+				shutdownPanic <- panicValue
+			}()
+			ready.Done()
+			<-start
+			test.Shutdown()
+		}()
+
+		ready.Wait()
+		close(start)
+		result := <-actorResult
+		require.Nil(t, <-shutdownPanic)
+
+		if result.panicValue == nil {
+			require.NotNil(t, result.actor)
+			require.Equal(t, "Alice", result.actor.Name())
+		} else {
+			require.Equal(t, "verity: ActorCalled called after Shutdown", result.panicValue)
+			require.Nil(t, result.actor)
+		}
+
+		require.Nil(t, concrete.actors, "shutdown must not leave a hidden actor registry")
+		require.Empty(t, test.Actors())
+		require.PanicsWithValue(t, "verity: ActorCalled called after Shutdown", func() {
+			test.ActorCalled("Bob")
+		})
+		require.Equal(t, int64(1), reporter.finishCount.Load())
+	}
+}
+
+func TestVerityTestShutdown_RepeatedAndConcurrentCallsReportExactlyOnce(t *testing.T) {
+	t.Parallel()
+	const callers = 64
+
+	reporter := &countingReporter{}
+	test := NewVerityTest(t, Scene{Reporter: reporter})
 	test.ActorCalled("Alice")
 
-	actors := test.Actors()
+	var ready sync.WaitGroup
+	ready.Add(callers)
+	start := make(chan struct{})
+	panics := make(chan any, callers)
+	var callersWG sync.WaitGroup
+	callersWG.Add(callers)
+	for range callers {
+		go func() {
+			defer callersWG.Done()
+			var panicValue any
+			defer func() {
+				panicValue = recover()
+				panics <- panicValue
+			}()
+			ready.Done()
+			<-start
+			test.Shutdown()
+		}()
+	}
 
-	require.NotNil(t, actors)
-	require.Empty(t, actors)
+	ready.Wait()
+	close(start)
+	callersWG.Wait()
+	close(panics)
+	for panicValue := range panics {
+		require.Nil(t, panicValue)
+	}
+
+	test.Shutdown()
+	require.Equal(t, int64(1), reporter.finishCount.Load())
+	require.Nil(t, test.(*verityTest).actors)
+	require.Empty(t, test.Actors())
+	require.PanicsWithValue(t, "verity: ActorCalled called after Shutdown", func() {
+		test.ActorCalled("Bob")
+	})
 }
 
 func TestVerityTestActors_ConcurrentSnapshotsAreConsistent(t *testing.T) {
@@ -415,9 +552,11 @@ func TestVerityTestActors_ConcurrentSnapshotsAreConsistent(t *testing.T) {
 	const actorCount = 64
 	const registrationsPerActor = 4
 	const readers = 8
+	const snapshotsPerReader = 256
 
+	var ready sync.WaitGroup
+	ready.Add(readers + actorCount*registrationsPerActor)
 	start := make(chan struct{})
-	done := make(chan struct{})
 	errs := make(chan error, readers)
 
 	var readerWG sync.WaitGroup
@@ -425,14 +564,9 @@ func TestVerityTestActors_ConcurrentSnapshotsAreConsistent(t *testing.T) {
 		readerWG.Add(1)
 		go func() {
 			defer readerWG.Done()
+			ready.Done()
 			<-start
-			for {
-				select {
-				case <-done:
-					return
-				default:
-				}
-
+			for range snapshotsPerReader {
 				actors := test.Actors()
 				if actors == nil {
 					errs <- fmt.Errorf("Actors returned a nil snapshot")
@@ -457,14 +591,15 @@ func TestVerityTestActors_ConcurrentSnapshotsAreConsistent(t *testing.T) {
 		writerWG.Add(1)
 		go func() {
 			defer writerWG.Done()
+			ready.Done()
 			<-start
 			test.ActorCalled(fmt.Sprintf("Actor-%02d", i%actorCount))
 		}()
 	}
 
+	ready.Wait()
 	close(start)
 	writerWG.Wait()
-	close(done)
 	readerWG.Wait()
 	close(errs)
 	for err := range errs {


### PR DESCRIPTION
## Summary
- Exposes deterministic, isolated snapshots of actors registered with a Verity test.
- Preserves actor identity while protecting the mutable registry.

## API contract
- Adds `Actors() []Actor` to `VerityTest`.
- Returns a fresh, non-nil snapshot sorted by case-sensitive actor name; returns an empty snapshot after shutdown.

## Test plan
- `go test ./...`
- `go test -race ./internal/testing`
- Covers public API compilation, snapshot isolation and ordering, concurrent registration, and shutdown lifecycle behavior.

## ADR
- Documents the snapshot, ordering, identity, concurrency, and lifecycle decisions in `docs/adr/0001-actor-registry-snapshots.md`.

Closes #41