### PR TITLE
refactor(api): replace mutable function aliases

### DIFF
--- a/core_api.go
+++ b/core_api.go
@@ -358,7 +358,9 @@ const (
 //		Do("authenticates with API", authenticate),
 //		Do("verifies session", verifySession),
 //	)
-var Do = internalcore.Do
+func Do(description string, perform func(context.Context, Actor) error) Interaction {
+	return internalcore.Do(description, perform)
+}
 
 // TaskWhere creates a new task with the given description and activities.
 // This is the factory function for creating composed tasks that represent
@@ -383,7 +385,9 @@ var Do = internalcore.Do
 //	if err != nil {
 //		return fmt.Errorf("test workflow failed: %w", err)
 //	}
-var TaskWhere = internalcore.TaskWhere
+func TaskWhere(description string, activities ...Activity) Task {
+	return internalcore.TaskWhere(description, activities...)
+}
 
 // Critical returns a failure mode that stops execution on failure.
 // This is a semantic function that returns FailFast mode.
@@ -398,7 +402,9 @@ var TaskWhere = internalcore.TaskWhere
 //		Do("establishes database connection", connectDB).WithFailureMode(Critical()),
 //		Do("creates user account", createUser),
 //	)
-var Critical = internalcore.Critical
+func Critical() FailureMode {
+	return internalcore.Critical()
+}
 
 // NonCritical returns a failure mode that logs errors but continues.
 // This is a semantic function that returns ErrorButContinue mode.
@@ -414,7 +420,9 @@ var Critical = internalcore.Critical
 //		Do("collects usage metrics", collectMetrics).WithFailureMode(NonCritical()),
 //		Do("verifies result", verifyResult),
 //	)
-var NonCritical = internalcore.NonCritical
+func NonCritical() FailureMode {
+	return internalcore.NonCritical()
+}
 
 // Optional returns a failure mode that ignores errors completely.
 // This is a semantic function that returns Ignore mode.
@@ -430,10 +438,14 @@ var NonCritical = internalcore.NonCritical
 //		Do("attempts to cleanup resources", cleanup).WithFailureMode(Optional()),
 //		Do("final assertion", finalAssertion),
 //	)
-var Optional = internalcore.Optional
+func Optional() FailureMode {
+	return internalcore.Optional()
+}
 
 // AbilityName returns the readable name of the provided ability instance.
-var AbilityName = internalcore.AbilityName
+func AbilityName(ability Ability) string {
+	return internalcore.AbilityName(ability)
+}
 
 // QuestionAbout creates a new question with the given description and ask function.
 // It panics if ask is nil.

--- a/exported_function_policy_test.go
+++ b/exported_function_policy_test.go
@@ -1,0 +1,88 @@
+package verity_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPublicAPIDoesNotAliasInternalFunctions(t *testing.T) {
+	t.Parallel()
+
+	allowedVariables := map[string]bool{
+		"LastResponseStatusQ": true,
+		"LastResponseBodyQ":   true,
+		"ResponseTimeQ":       true,
+	}
+
+	err := filepath.WalkDir(".", func(filename string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if filename != "." && (entry.Name() == "internal" || strings.HasPrefix(entry.Name(), ".")) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(filename, "_test.go") || filepath.Ext(filename) != ".go" {
+			return nil
+		}
+
+		fileset := token.NewFileSet()
+		file, err := parser.ParseFile(fileset, filename, nil, 0)
+		if err != nil {
+			return err
+		}
+
+		internalImports := map[string]bool{}
+		for _, spec := range file.Imports {
+			importPath, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				return err
+			}
+			if !strings.Contains(importPath, "/internal/") && !strings.HasSuffix(importPath, "/internal") {
+				continue
+			}
+			name := path.Base(importPath)
+			if spec.Name != nil {
+				name = spec.Name.Name
+			}
+			internalImports[name] = true
+		}
+
+		for _, declaration := range file.Decls {
+			general, ok := declaration.(*ast.GenDecl)
+			if !ok || general.Tok != token.VAR {
+				continue
+			}
+			for _, rawSpec := range general.Specs {
+				spec := rawSpec.(*ast.ValueSpec)
+				for index, name := range spec.Names {
+					allowedQuestion := filepath.ToSlash(filename) == "verity_abilities/api/api.go" && allowedVariables[name.Name]
+					if !ast.IsExported(name.Name) || allowedQuestion || index >= len(spec.Values) {
+						continue
+					}
+					selector, ok := spec.Values[index].(*ast.SelectorExpr)
+					if !ok {
+						continue
+					}
+					packageName, ok := selector.X.(*ast.Ident)
+					if ok && internalImports[packageName.Name] {
+						t.Errorf("%s:%d: exported var %s aliases internal callable %s.%s; use a typed wrapper function", filename, fileset.Position(name.Pos()).Line, name.Name, packageName.Name, selector.Sel.Name)
+					}
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan public API: %v", err)
+	}
+}

--- a/function_signatures_test.go
+++ b/function_signatures_test.go
@@ -1,0 +1,20 @@
+package verity_test
+
+import (
+	"context"
+
+	verity "github.com/verity-bdd/verity-bdd"
+	reporting "github.com/verity-bdd/verity-bdd/verity_reporting"
+)
+
+var (
+	_ func(string, func(context.Context, verity.Actor) error) verity.Interaction      = verity.Do
+	_ func(string, ...verity.Activity) verity.Task                                    = verity.TaskWhere
+	_ func() verity.FailureMode                                                       = verity.Critical
+	_ func() verity.FailureMode                                                       = verity.NonCritical
+	_ func() verity.FailureMode                                                       = verity.Optional
+	_ func(verity.Ability) string                                                     = verity.AbilityName
+	_ func(verity.TestContext, verity.Scene) verity.VerityTest                        = verity.NewVerityTest
+	_ func(context.Context, verity.TestContext) verity.VerityTest                     = verity.NewVerityTestWithContext
+	_ func(context.Context, verity.TestContext, reporting.Reporter) verity.VerityTest = verity.NewVerityTestWithReporter
+)

--- a/testing_api.go
+++ b/testing_api.go
@@ -1,7 +1,10 @@
 package verity
 
 import (
+	"context"
+
 	internaltesting "github.com/verity-bdd/verity-bdd/internal/testing"
+	reporting "github.com/verity-bdd/verity-bdd/verity_reporting"
 )
 
 // ReporterProvider provides access to reporter adapter.
@@ -37,10 +40,16 @@ type VerityTest = internaltesting.VerityTest
 type TestContext = internaltesting.TestContext
 
 // NewVerityTest creates a new VerityTest instance.
-var NewVerityTest = internaltesting.NewVerityTest
+func NewVerityTest(t TestContext, scene Scene) VerityTest {
+	return internaltesting.NewVerityTest(t, scene)
+}
 
 // NewVerityTestWithContext creates a new VerityTest instance using the provided context.
-var NewVerityTestWithContext = internaltesting.NewVerityTestWithContext
+func NewVerityTestWithContext(ctx context.Context, t TestContext) VerityTest {
+	return internaltesting.NewVerityTestWithContext(ctx, t)
+}
 
 // NewVerityTestWithReporter creates a new VerityTest instance with a reporter.
-var NewVerityTestWithReporter = internaltesting.NewVerityTestWithReporter
+func NewVerityTestWithReporter(ctx context.Context, t TestContext, reporter reporting.Reporter) VerityTest {
+	return internaltesting.NewVerityTestWithReporter(ctx, t, reporter)
+}

--- a/verity_abilities/api/api.go
+++ b/verity_abilities/api/api.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net/http"
+
 	verity "github.com/verity-bdd/verity-bdd"
 	internalapi "github.com/verity-bdd/verity-bdd/internal/abilities/api"
 )
@@ -30,38 +32,60 @@ type JSONPath = internalapi.JSONPath
 type ResponseTime = internalapi.ResponseTime
 
 // Using creates a new CallAnAPI ability with the given HTTP client.
-var Using = internalapi.Using
+func Using(client *http.Client) CallAnAPI {
+	return internalapi.Using(client)
+}
 
 // CallAnApiAt creates a new CallAnAPI ability with the given base URL.
 // Panics if the base URL is invalid.
-var CallAnApiAt = internalapi.CallAnApiAt
+func CallAnApiAt(baseURL string) CallAnAPI {
+	return internalapi.CallAnApiAt(baseURL)
+}
 
 // NewRequestBuilder creates a new request builder for the given HTTP method and URL.
-var NewRequestBuilder = internalapi.NewRequestBuilder
+func NewRequestBuilder(method, url string) *RequestBuilder {
+	return internalapi.NewRequestBuilder(method, url)
+}
 
 // SendRequest creates an activity that sends the given HTTP request.
-var SendRequest = internalapi.SendRequest
+func SendRequest(request *http.Request) verity.Activity {
+	return internalapi.SendRequest(request)
+}
 
 // SendGetRequest creates a GET request activity with a fluent interface for the given URL.
-var SendGetRequest = internalapi.SendGetRequest
+func SendGetRequest(url string) *RequestActivity {
+	return internalapi.SendGetRequest(url)
+}
 
 // SendPostRequest creates a POST request activity with a fluent interface for the given URL.
-var SendPostRequest = internalapi.SendPostRequest
+func SendPostRequest(url string) *RequestActivity {
+	return internalapi.SendPostRequest(url)
+}
 
 // SendPutRequest creates a PUT request activity with a fluent interface for the given URL.
-var SendPutRequest = internalapi.SendPutRequest
+func SendPutRequest(url string) *RequestActivity {
+	return internalapi.SendPutRequest(url)
+}
 
 // SendDeleteRequest creates a DELETE request activity with a fluent interface for the given URL.
-var SendDeleteRequest = internalapi.SendDeleteRequest
+func SendDeleteRequest(url string) *RequestActivity {
+	return internalapi.SendDeleteRequest(url)
+}
 
 // SendPatchRequest creates a PATCH request activity with a fluent interface for the given URL.
-var SendPatchRequest = internalapi.SendPatchRequest
+func SendPatchRequest(url string) *RequestActivity {
+	return internalapi.SendPatchRequest(url)
+}
 
 // NewResponseHeader creates a new question that retrieves the named header from the last HTTP response.
-var NewResponseHeader = internalapi.NewResponseHeader
+func NewResponseHeader(key string) ResponseHeader {
+	return internalapi.NewResponseHeader(key)
+}
 
 // NewJSONPath creates a new question that extracts the value at the given JSON path from the last HTTP response body.
-var NewJSONPath = internalapi.NewJSONPath
+func NewJSONPath(path string) JSONPath {
+	return internalapi.NewJSONPath(path)
+}
 
 // LastResponseBodyAsJSON creates a question that parses the last HTTP response body as JSON into type T.
 func LastResponseBodyAsJSON[T any]() verity.Question[T] {

--- a/verity_abilities/api/function_signatures_test.go
+++ b/verity_abilities/api/function_signatures_test.go
@@ -1,0 +1,22 @@
+package api_test
+
+import (
+	"net/http"
+
+	verity "github.com/verity-bdd/verity-bdd"
+	"github.com/verity-bdd/verity-bdd/verity_abilities/api"
+)
+
+var (
+	_ func(*http.Client) api.CallAnAPI         = api.Using
+	_ func(string) api.CallAnAPI               = api.CallAnApiAt
+	_ func(string, string) *api.RequestBuilder = api.NewRequestBuilder
+	_ func(*http.Request) verity.Activity      = api.SendRequest
+	_ func(string) *api.RequestActivity        = api.SendGetRequest
+	_ func(string) *api.RequestActivity        = api.SendPostRequest
+	_ func(string) *api.RequestActivity        = api.SendPutRequest
+	_ func(string) *api.RequestActivity        = api.SendDeleteRequest
+	_ func(string) *api.RequestActivity        = api.SendPatchRequest
+	_ func(string) api.ResponseHeader          = api.NewResponseHeader
+	_ func(string) api.JSONPath                = api.NewJSONPath
+)

--- a/verity_abilities/take_notes/take_notes.go
+++ b/verity_abilities/take_notes/take_notes.go
@@ -13,22 +13,34 @@ type TakeNotesAbility = internalnotes.TakeNotesAbility
 type NoteBook = internalnotes.NoteBook
 
 // UsingEmptyNotepad returns a new ability instance with an empty notepad.
-var UsingEmptyNotepad = internalnotes.UsingEmptyNotepad
+func UsingEmptyNotepad() verity.Ability {
+	return internalnotes.UsingEmptyNotepad()
+}
 
 // Using returns an ability that stores notes in the provided notepad.
-var Using = internalnotes.Using
+func Using(notepad *NoteBook) verity.Ability {
+	return internalnotes.Using(notepad)
+}
 
 // NewNoteBook creates a new empty NoteBook.
-var NewNoteBook = internalnotes.NewNoteBook
+func NewNoteBook() *NoteBook {
+	return internalnotes.NewNoteBook()
+}
 
 // NotepadWith creates a notepad pre-filled with the provided values.
-var NotepadWith = internalnotes.NotepadWith
+func NotepadWith(initial map[string]any) *NoteBook {
+	return internalnotes.NotepadWith(initial)
+}
 
 // TakeNoteOf starts a TakeNote activity definition for the given value.
-var TakeNoteOf = internalnotes.TakeNoteOf
+func TakeNoteOf(value any) interface{ As(string) verity.Activity } {
+	return internalnotes.TakeNoteOf(value)
+}
 
 // NoteValue returns an untyped question that retrieves the note stored under the given key.
-var NoteValue = internalnotes.NoteValue
+func NoteValue(key string) verity.Question[any] {
+	return internalnotes.NoteValue(key)
+}
 
 // Note returns a typed question that retrieves the note stored under the given key as type T.
 func Note[T any](key string) verity.Question[T] {

--- a/verity_abilities/take_notes_function_signatures_test.go
+++ b/verity_abilities/take_notes_function_signatures_test.go
@@ -1,0 +1,15 @@
+package verity_abilities_test
+
+import (
+	verity "github.com/verity-bdd/verity-bdd"
+	"github.com/verity-bdd/verity-bdd/verity_abilities/take_notes"
+)
+
+var (
+	_ func() verity.Ability                             = take_notes.UsingEmptyNotepad
+	_ func(*take_notes.NoteBook) verity.Ability         = take_notes.Using
+	_ func() *take_notes.NoteBook                       = take_notes.NewNoteBook
+	_ func(map[string]any) *take_notes.NoteBook         = take_notes.NotepadWith
+	_ func(any) interface{ As(string) verity.Activity } = take_notes.TakeNoteOf
+	_ func(string) verity.Question[any]                 = take_notes.NoteValue
+)

--- a/verity_expectations/expectations.go
+++ b/verity_expectations/expectations.go
@@ -14,13 +14,19 @@ func ContainsSubstring(substring string) ensure.Expectation[string] {
 }
 
 // ContainsKey checks if a map contains the expected key.
-var ContainsKey = internalexpectations.ContainsKey
+func ContainsKey(key string) ensure.Expectation[interface{}] {
+	return internalexpectations.ContainsKey(key)
+}
 
 // IsGreaterThan checks if a numeric value is greater than the expected value.
-var IsGreaterThan = internalexpectations.IsGreaterThan
+func IsGreaterThan(expected interface{}) ensure.Expectation[interface{}] {
+	return internalexpectations.IsGreaterThan(expected)
+}
 
 // IsLessThan checks if a numeric value is less than the expected value.
-var IsLessThan = internalexpectations.IsLessThan
+func IsLessThan(expected interface{}) ensure.Expectation[interface{}] {
+	return internalexpectations.IsLessThan(expected)
+}
 
 // IsEmpty checks if a value is empty (string, slice, array, or map).
 func IsEmpty[T any]() ensure.Expectation[T] {

--- a/verity_expectations/function_signatures_test.go
+++ b/verity_expectations/function_signatures_test.go
@@ -1,0 +1,12 @@
+package verity_expectations_test
+
+import (
+	ve "github.com/verity-bdd/verity-bdd/verity_expectations"
+	"github.com/verity-bdd/verity-bdd/verity_expectations/ensure"
+)
+
+var (
+	_ func(string) ensure.Expectation[interface{}]      = ve.ContainsKey
+	_ func(interface{}) ensure.Expectation[interface{}] = ve.IsGreaterThan
+	_ func(interface{}) ensure.Expectation[interface{}] = ve.IsLessThan
+)

--- a/verity_reporting/allure_reporter/allure_reporter.go
+++ b/verity_reporting/allure_reporter/allure_reporter.go
@@ -4,4 +4,6 @@ import internalallure "github.com/verity-bdd/verity-bdd/internal/reporting/allur
 
 type AllureReporter = internalallure.AllureReporter
 
-var NewAllureReporterWithDir = internalallure.NewAllureReporterWithDir
+func NewAllureReporterWithDir(dir string) *AllureReporter {
+	return internalallure.NewAllureReporterWithDir(dir)
+}

--- a/verity_reporting/console_reporter/console_reporter.go
+++ b/verity_reporting/console_reporter/console_reporter.go
@@ -4,4 +4,6 @@ import internalconsole "github.com/verity-bdd/verity-bdd/internal/reporting/cons
 
 type ConsoleReporter = internalconsole.ConsoleReporter
 
-var NewConsoleReporter = internalconsole.NewConsoleReporter
+func NewConsoleReporter() *ConsoleReporter {
+	return internalconsole.NewConsoleReporter()
+}

--- a/verity_reporting/function_signatures_test.go
+++ b/verity_reporting/function_signatures_test.go
@@ -1,0 +1,15 @@
+package verity_reporting_test
+
+import (
+	vr "github.com/verity-bdd/verity-bdd/verity_reporting"
+	"github.com/verity-bdd/verity-bdd/verity_reporting/allure_reporter"
+	"github.com/verity-bdd/verity-bdd/verity_reporting/console_reporter"
+)
+
+var (
+	_ func(vr.Reporter) *vr.TestRunnerAdapter               = vr.NewTestRunnerAdapter
+	_ func(vr.Reporter, string) *vr.ActivityTracker         = vr.NewActivityTracker
+	_ func(vr.Reporter, string, string) *vr.ActivityTracker = vr.NewActivityTrackerWithActor
+	_ func() *console_reporter.ConsoleReporter              = console_reporter.NewConsoleReporter
+	_ func(string) *allure_reporter.AllureReporter          = allure_reporter.NewAllureReporterWithDir
+)

--- a/verity_reporting/reporter.go
+++ b/verity_reporting/reporter.go
@@ -31,10 +31,16 @@ type TestRunnerAdapter = internalreporting.TestRunnerAdapter
 type ActivityTracker = internalreporting.ActivityTracker
 
 // NewTestRunnerAdapter creates a new test runner adapter.
-var NewTestRunnerAdapter = internalreporting.NewTestRunnerAdapter
+func NewTestRunnerAdapter(reporter Reporter) *TestRunnerAdapter {
+	return internalreporting.NewTestRunnerAdapter(reporter)
+}
 
 // NewActivityTracker creates a new activity tracker.
-var NewActivityTracker = internalreporting.NewActivityTracker
+func NewActivityTracker(reporter Reporter, activity string) *ActivityTracker {
+	return internalreporting.NewActivityTracker(reporter, activity)
+}
 
 // NewActivityTrackerWithActor creates a new activity tracker with an actor name.
-var NewActivityTrackerWithActor = internalreporting.NewActivityTrackerWithActor
+func NewActivityTrackerWithActor(reporter Reporter, activity, actorName string) *ActivityTracker {
+	return internalreporting.NewActivityTrackerWithActor(reporter, activity, actorName)
+}


### PR DESCRIPTION
## Summary
- replace all 34 exported mutable callable aliases with typed wrapper functions
- preserve public call syntax and the three intentional pre-built API questions
- expose the minimal fluent `TakeNoteOf(value).As(key)` contract without leaking its internal builder
- add repository policy and compile-time signature contract tests

## Verification
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run`
- `go mod tidy -diff`
- independent pre-PR review: passed on iteration 1/3

Resolves #45
