### PR TITLE
ci: align Go versions with module requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.22, 1.23, 1.24]
+        go-version: ['1.23.4', '1.24.x']
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.22, 1.23, 1.24]
+        go-version: ['1.23.4', '1.24.x']
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23
+        go-version: '1.23.4'
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -132,9 +132,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.23-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.23.4-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-1.23-
+          ${{ runner.os }}-go-1.23.4-
 
     - name: Download dependencies
       run: go mod download


### PR DESCRIPTION
## Summary
- replace the misleading Go 1.22/1.23/1.24 test matrices with the exact supported minimum Go 1.23.4 and Go 1.24.x
- run golangci-lint with Go 1.23.4
- align lint cache keys with the exact toolchain version

## Verification
- `actionlint .github/workflows/ci.yml`
- GitHub Actions CI on this PR

Resolves #46
