### PR TITLE
docs: align library documentation with current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,543 +3,269 @@
 ![CI](https://github.com/verity-bdd/verity-bdd/workflows/CI/badge.svg) ![codecov](https://codecov.io/gh/nchursin/verity-bdd/graph/badge.svg) ![Version](https://img.shields.io/github/v/release/nchursin/verity-bdd)
 
 > [!WARNING]
-> This project is still at version 0.x.x. It means I do not guarantee ANY backwards compatibility for ANY changes. I use this project daily and adjust the API to real world usage.
-> The plan is to go v1.x.x in Summer 2026.
+> Verity-BDD is still at version 0.x. Backwards compatibility is not guaranteed before v1.
 
-A Go implementation of the Screenplay Pattern for acceptance testing, focused on API testing capabilities.
+Verity-BDD is a Go implementation of the Screenplay Pattern, focused on acceptance and HTTP API testing. It requires **Go 1.23.4 or later**.
 
-![Verity-BDD](https://raw.githubusercontent.com/nchursin/resources/refs/heads/master/verity-bdd/dark.png)
-
-## Overview
-
-Verity-BDD brings the power of the Screenplay Pattern to Go testing, providing:
-
-- **Actor-centric testing** - Tests describe what actors do, not how they do it
-- **Reusable components** - Build a library of reusable tasks and interactions
-- **Clear domain language** - Tests that read like business requirements
-- **Modular design** - Use only what you need for your testing scenarios
-- **Framework agnostic** - Works with any Go test runner
-
-## Quick Start
-
-### Installation
+## Installation
 
 ```bash
 go get github.com/verity-bdd/verity-bdd
 ```
 
-### Basic Example
+## Quick start
 
 ```go
-package main
+package example
 
 import (
     "testing"
 
+    verity "github.com/verity-bdd/verity-bdd"
     "github.com/verity-bdd/verity-bdd/verity_abilities/api"
     expectations "github.com/verity-bdd/verity-bdd/verity_expectations"
     "github.com/verity-bdd/verity-bdd/verity_expectations/ensure"
-    verity "github.com/verity-bdd/verity-bdd"
 )
 
 func TestAPI(t *testing.T) {
     test := verity.NewVerityTest(t, verity.Scene{})
 
-    // Create an actor with API ability
-    actor := test.ActorCalled("APITester").WhoCan(
-        api.CallAnApiAt("https://jsonplaceholder.typicode.com"),
+    actor := test.ActorCalled("API tester").WhoCan(
+        api.CallAnApiAt("https://api.example.com"),
     )
 
-    // Define test data
-    newPost := map[string]interface{}{
-        "title":  "Test Post",
-        "body":   "This is a test post",
-        "userId": 1,
-    }
-
-    // Test the API
     actor.AttemptsTo(
-        api.SendPostRequest("/posts").
-            WithBody(newPost),
+        api.SendPostRequest("/posts").WithBody(map[string]any{
+            "title": "A test post",
+        }),
         ensure.That(api.LastResponseStatus{}, expectations.Equals(201)),
-        ensure.That(api.LastResponseBody{}, expectations.ContainsSubstring("Test Post")),
+        ensure.That(api.LastResponseBody{}, expectations.ContainsSubstring("A test post")),
     )
 }
 ```
 
-## Core Concepts
+`AttemptsTo` reports activity failures through the test context and does not return an error. `NewVerityTest` registers cleanup automatically with `testing.T.Cleanup`; calling `Shutdown` explicitly is optional and idempotent.
 
-### Actors
+## Core API
 
-Actors represent people or systems interacting with your application:
+### Actors and abilities
 
-```go
-test := verity.NewVerityTest(t, verity.Scene{})
-
-// Create an actor
-actor := test.ActorCalled("John Doe")
-
-// Give the actor abilities to interact with your system
-actor = actor.WhoCan(api.CallAnApiAt("https://api.example.com"))
-```
-
-### Abilities
-
-Abilities enable actors to interact with different interfaces:
+Actors represent people or external systems. `WhoCan` attaches abilities:
 
 ```go
-test := verity.NewVerityTest(t, verity.Scene{})
-
-// HTTP API ability
-apiAbility := api.CallAnApiAt("https://api.example.com")
-
-// Actor with multiple abilities
-actor := test.ActorCalled("TestUser").WhoCan(
-    apiAbility,
-    // ... other abilities
+actor := test.ActorCalled("Customer").WhoCan(
+    api.CallAnApiAt("https://api.example.com"),
 )
 ```
 
-### Activities
+`verity.Ability` is currently an empty interface, so any Go value can be an ability. Embedding it in a custom interface is optional documentation, not an enforced requirement. Retrieve a typed ability with `verity.AbilityOf[T]`:
 
-Activities represent actions that actors perform:
-
-#### Interactions (low-level actions)
 ```go
-// Send HTTP requests with fluent interface
-api.SendGetRequest("/users")
-api.SendPostRequest("/posts").WithBody(postData)
-api.SendPutRequest("/users/1").WithBody(updatedUser)
-api.SendPatchRequest("/users/1").WithBody(partialUpdate)
-api.SendDeleteRequest("/posts/123")
+apiAbility, err := verity.AbilityOf[api.CallAnAPI](actor)
+if err != nil {
+    return err
+}
+_ = apiAbility
 ```
 
-#### Tasks (high-level business actions)
+### Interactions and tasks
+
+Use `verity.Do` for a custom interaction and `verity.TaskWhere` to compose activities:
+
 ```go
-// Define reusable task
-createUserTask := core.Where(
-    "creates a new user",
-    core.Do("creates a new user", func(a core.Actor) error {
-        req, err := api.NewRequestBuilder("POST", "/users").
-            WithJSONBody(userData).
-            Build()
-        if err != nil {
-            return err
-        }
-        return api.SendRequest(req).PerformAs(a)
+createUser := verity.TaskWhere(
+    "creates a user",
+    verity.Do("prepares user data", func(ctx context.Context, actor verity.Actor) error {
+        return nil
     }),
+    api.SendPostRequest("/users").WithBody(userData),
     ensure.That(api.LastResponseStatus{}, expectations.Equals(201)),
 )
 
-// Use the task
-actor.AttemptsTo(createUserTask)
+actor.AttemptsTo(createUser)
+```
+
+The callback signature is `func(context.Context, verity.Actor) error`. Activities created by `verity.Do` are fail-fast interactions. The exported `Critical`, `NonCritical`, and `Optional` functions return `FailureMode` values for custom activity implementations: `NonCritical` marks the test failed but continues, while `Optional` logs and continues without failing the test. `Interaction` does not currently have a `WithFailureMode` method.
+
+### Task composition
+
+Use `TaskWhere` to name a business workflow and combine reusable activities. Nested tasks stop at the first failing child activity:
+
+```go
+checkout := verity.TaskWhere("checks out an order", addItems, submitPayment, confirmOrder)
+actor.AttemptsTo(checkout)
+```
+
+### Multiple actors
+
+Create separate actors when a scenario has distinct personas. Each actor keeps its own abilities and state:
+
+```go
+admin := test.ActorCalled("Admin").WhoCan(api.CallAnApiAt(baseURL))
+customer := test.ActorCalled("Customer").WhoCan(api.CallAnApiAt(baseURL))
+
+admin.AttemptsTo(createProduct)
+customer.AttemptsTo(orderProduct)
 ```
 
 ### Questions
 
-Questions retrieve information from the system:
+A question implements:
 
 ```go
-// Basic built-in questions
-ensure.That(api.LastResponseStatus{}, expectations.Equals(200))
-ensure.That(api.LastResponseBody{}, expectations.ContainsSubstring("success"))
-ensure.That(api.NewResponseHeader("content-type"), expectations.ContainsSubstring("json"))
-
-// Advanced questions with JSON parsing
-type User struct {
-    ID    int    `json:"id"`
-    Name  string `json:"name"`
-    Email string `json:"email"`
+type Question[T any] interface {
+    Description() string
+    AnsweredBy(context.Context, verity.Actor) (T, error)
 }
+```
 
-err := actor.AttemptsTo(
-    api.SendGetRequest("/users/1"),
-    ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
+Create dynamic questions with `verity.QuestionAbout`:
 
-    // Parse response as JSON struct
-    ensure.That(api.LastResponseBodyAsJSON[User](), expectations.Satisfies("has valid user", func(actual User) error {
-        if actual.Name == "" {
-            return fmt.Errorf("user name is empty")
-        }
-        if !strings.Contains(actual.Email, "@") {
-            return fmt.Errorf("invalid email format")
-        }
-        return nil
-    })),
+```go
+name := verity.QuestionAbout("customer name", func(ctx context.Context, actor verity.Actor) (string, error) {
+    return "Alice", nil
+})
 
-    // JSONPath queries
-    ensure.That(api.NewJSONPath("name"), expectations.ContainsSubstring("John")),
-    ensure.That(api.NewJSONPath("data.users.*.email"), expectations.ContainsSubstring("@")),
-
-    // Response time validation
-    ensure.That(api.ResponseTime{}, expectations.IsLessThan(1000)), // milliseconds
+actor.AttemptsTo(
+    ensure.That(name, expectations.Equals("Alice")),
 )
 ```
 
-### Assertions
+Wrap static values with `verity_answerable.ValueOf`.
 
-Verify that expectations are met:
+## HTTP API testing
+
+Give an actor `api.CallAnApiAt(baseURL)` or provide a custom client with `api.Using(client)`.
+
+Request activities support `WithBody`, `WithHeader`, and `WithHeaders`:
+
+```go
+actor.AttemptsTo(
+    api.SendPutRequest("/users/1").
+        WithHeader("Authorization", "Bearer token").
+        WithBody(updatedUser),
+)
+```
+
+For a pre-built `*http.Request`, use `api.SendRequest(req)`. `api.NewRequestBuilder` is also available when request construction needs to be separated from execution.
+
+Current response questions include:
+
+- `api.LastResponseStatus{}` and `api.LastResponseStatusQ` (`int`)
+- `api.LastResponseBody{}` and `api.LastResponseBodyQ` (`string`)
+- `api.NewResponseHeader(name)` (`string`)
+- `api.LastResponseBodyAsJSON[T]()` (`T`)
+- `api.NewJSONPath(path)` (`any`)
+- `api.ResponseTime{}` and `api.ResponseTimeQ` (`int64`, currently always `0`)
+
+`NewJSONPath` decodes JSON into ordinary Go JSON values: objects become `map[string]any`, arrays become `[]any`, numbers become `float64`, and wildcard paths can return `[]any`. Because its question type is `any`, use an `ensure.Expectation[any]` such as `expectations.Equals[any](...)` or create a typed question with `LastResponseBodyAsJSON[T]`.
+
+Response timing is not implemented. `ResponseTime` and `ResponseTimeQ` currently return `0`; do not use them to assert measured latency.
+
+## Expectations
 
 ```go
 ensure.That(question, expectations.Equals(expected))
-ensure.That(question, expectations.ContainsSubstring(substring))
-ensure.That(itemsQuestion, expectations.Includes(expectedItem))
-ensure.That(question, expectations.IsEmpty())
-ensure.That(question, expectations.ArrayLengthEquals(5))
-ensure.That(question, expectations.IsGreaterThan(10))
-ensure.That(question, expectations.ContainsKey("id"))
-
-// Custom validation with Satisfies
-ensure.That(answerable.ValueOf(value), expectations.Satisfies("custom description", func(actual T) error {
-    // Your validation logic here
-    return nil // or error with description
-}))
+ensure.That(stringQuestion, expectations.ContainsSubstring("text"))
+ensure.That(sliceQuestion, expectations.Includes(item))
+ensure.That(question, expectations.IsEmpty[T]())
+ensure.That(question, expectations.ArrayLengthEquals[T](5))
+ensure.That(numberQuestion, expectations.IsGreaterThan(10)) // numberQuestion is verity.Question[any]
+ensure.That(mapQuestion, expectations.ContainsKey("id"))
 ```
 
-## API Testing
+`Equals` uses deep equality. `IsEmpty` supports strings, slices, arrays, and maps. `ArrayLengthEquals` supports arrays, slices, and strings.
 
-### HTTP Requests
+Use `expectations.Satisfies` for custom validation. Dynamic factories such as `EqualsAnswerTo`, `ContainsSubstringAnswerTo`, `ContainsKeyAnswerTo`, `ArrayLengthEqualsAnswerTo`, the numeric `*AnswerTo` variants, and `SatisfiesAnswer` can evaluate another question or use the current context and actor.
+
+`ensure.That(...).After(duration)` delays once before evaluating. It does **not** poll. For polling, use the wait ability:
 
 ```go
-// GET request
-err := actor.AttemptsTo(
-    api.SendGetRequest("/posts"),
-    ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
-)
-
-// POST request with JSON data
-newPost := map[string]interface{}{
-    "title":  "New Post",
-    "body":   "Post content",
-    "userId": 1,
-}
-
-err = actor.AttemptsTo(
-    api.SendPostRequest("/posts").
-        WithBody(newPost),
-    ensure.That(api.LastResponseStatus{}, expectations.Equals(201)),
-)
-
-// PUT request with single header
-err = actor.AttemptsTo(
-    api.SendPutRequest("/posts/1").
-        WithHeader("Authorization", "Bearer token").
-        WithBody(updatedData),
-    ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
-)
-
-// PUT request with multiple headers
-err = actor.AttemptsTo(
-    api.SendPutRequest("/posts/1").
-        WithHeaders(map[string]string{
-            "Content-Type": "application/json",
-            "Authorization": "Bearer token",
-            "X-Custom-Header": "custom-value",
-        }).
-        WithBody(updatedData),
-    ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
-)
-
-// DELETE request
-err = actor.AttemptsTo(
-    api.SendDeleteRequest("/posts/1"),
-    ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
+actor.AttemptsTo(
+    wait.Until(statusQuestion, expectations.Equals("ready")).
+        For(10 * time.Second).
+        CheckingEvery(250 * time.Millisecond),
 )
 ```
 
-### Request Building
+Use `wait.UntilReceived(channel).For(timeout)` to wait for a channel value.
+
+## Notes
+
+Attach `take_notes.UsingEmptyNotepad()` to an actor, record values with `TakeNoteOf(...).As(...)`, and ask for them with `Note[T]`:
 
 ```go
-// Fluent request building
-err = actor.AttemptsTo(
-    api.SendPostRequest("/posts").
-        WithHeader("Content-Type", "application/json").
-        WithHeader("Authorization", "Bearer token").
-        WithBody(postData),
-)
-```
+actor := test.ActorCalled("Nina").WhoCan(take_notes.UsingEmptyNotepad())
+actor.AttemptsTo(take_notes.TakeNoteOf("Bearer abc123").As("auth token"))
 
-### Response Validation
-
-```go
-err := actor.AttemptsTo(
-    api.SendGetRequest("/posts/1").
-        WithHeader("Accept", "application/json"),
-    ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
-    ensure.That(api.LastResponseBody{}, expectations.ContainsSubstring("title")),
-    ensure.That(api.NewResponseHeader("content-type"), expectations.ContainsSubstring("json")),
-)
-```
-
-## Console Reporting
-
-Verity-BDD provides automatic console reporting for test results with emoji indicators, timing information, and detailed error messages.
-
-### Automatic Integration
-
-The TestContext API automatically provides console reporting:
-
-```go
-func TestAPITesting(t *testing.T) {
-    test := verity.NewVerityTest(t, verity.Scene{})
-
-    actor := test.ActorCalled("APITester").WhoCan(api.CallAnApiAt("https://jsonplaceholder.typicode.com"))
-
-    actor.AttemptsTo(
-        api.SendGetRequest("/posts"),
-        ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
-    )
-}
-```
-
-Console output:
-```
-🚀 Starting: TestAPITesting
-  🔄 Sends GET request to /posts
-  ✅ Sends GET request to /posts (0.21s)
-  🔄 Ensures that the last response status code equals 200
-  ✅ Ensures that the last response status code equals 200 (0.00s)
-✅ TestAPITesting: PASSED (0.26s)
-```
-
-### Output Format
-
-| Status | Emoji | Description |
-|--------|-------|-------------|
-| ✅ | ✅ | Test passed |
-| ❌ | ❌ | Test failed |
-| ⚠️ | ⚠️ | Warning (unused actor) |
-
-Example output:
-```
-🚀 Starting: TestAPITesting
-  🔄 Sends GET request to /posts
-  ✅ Sends GET request to /posts (0.21s)
-  🔄 Ensures that the last response status code equals 200
-  ✅ Ensures that the last response status code equals 200 (0.00s)
-✅ TestAPITesting: PASSED (0.26s)
-
-🚀 Starting: TestFailedExpectation
-  🔄 Sends GET request to /posts
-  ❌ Sends GET request to /posts (0.15s)
-     Error: Expected status code to equal 200, but got 404
-❌ TestFailedExpectation: FAILED (0.15s)
-```
-
-### Custom Configuration
-
-```go
-import (
-    "os"
-    "github.com/verity-bdd/verity-bdd/verity_reporting/console_reporter"
-    verity "github.com/verity-bdd/verity-bdd"
-)
-
-// Create custom console reporter
-reporter := console_reporter.NewConsoleReporter()
-
-test := verity.NewVerityTestWithReporter(t, reporter)
-```
-
-For detailed documentation on console reporting, see [docs/reporting.md](docs/reporting.md).
-
-### File Output
-
-```go
-import (
-    "os"
-    "github.com/verity-bdd/verity-bdd/verity_reporting/console_reporter"
-    verity "github.com/verity-bdd/verity-bdd"
-)
-
-// Create file for output
-file, err := os.Create("test-results.txt")
+token, err := take_notes.Note[string]("auth token").AnsweredBy(test.Context(), actor)
 if err != nil {
-    t.Fatalf("Failed to create file: %v", err)
+    t.Fatal(err)
 }
-defer file.Close()
+_ = token
+```
 
-// Create reporter with file output
+## Reporting
+
+The default reporter writes test start, completed-step, and test-finish lines to stdout. `OnStepStart` tracks nesting but does not print a separate “in progress” line.
+
+Supply a reporter either in `Scene` or with the three-argument helper:
+
+```go
 reporter := console_reporter.NewConsoleReporter()
-reporter.SetOutput(file)
+reporter.SetOutput(os.Stdout)
 
-test := verity.NewVerityTestWithReporter(t, reporter)
+test := verity.NewVerityTestWithReporter(context.Background(), t, reporter)
 ```
 
-For detailed documentation on console reporting, see [docs/reporting.md](docs/reporting.md).
-
-## Allure Reporting
-
-Verity-BDD includes a native Allure reporter that writes Allure 2 result files, step data, and attachments.
+The native Allure reporter writes Allure 2 result JSON:
 
 ```go
-import (
-    "context"
-
-    "github.com/verity-bdd/verity-bdd/verity_reporting/allure_reporter"
-    verity "github.com/verity-bdd/verity-bdd"
-)
-
-func TestWithAllure(t *testing.T) {
-    reporter := allure_reporter.NewAllureReporterWithDir("allure-results")
-
-    test := verity.NewVerityTest(t, verity.Scene{
-        Context:  context.Background(),
-        Reporter: reporter,
-    })
-
-    actor := test.ActorCalled("Tester")
-    actor.AttemptsTo(
-        // your activities
-    )
-}
+reporter := allure_reporter.NewAllureReporterWithDir("allure-results")
+test := verity.NewVerityTestWithReporter(context.Background(), t, reporter)
 ```
 
-Generate a local HTML report after test run:
+The public reporting model can represent step attachments, but the actor execution pipeline currently finishes steps without producing any. Built-in test shutdown supplies only the test-level `notes` JSON attachment when actors have notes. Custom reporter implementations should therefore expect `OnStepFinish` attachments to be empty in normal Verity execution.
+
+The root `verity.TestResult`/`verity.Status` types describe core test state. `verity_reporting.TestResult`/`verity_reporting.Status` are separate callback contracts used by reporters.
+
+See [docs/reporting.md](docs/reporting.md) for reporter details.
+
+## Public package architecture
+
+Production code is exposed through these importable packages:
+
+- `github.com/verity-bdd/verity-bdd` — actors, activities, questions, test lifecycle
+- `github.com/verity-bdd/verity-bdd/verity_abilities/api` — HTTP ability, requests, response questions
+- `github.com/verity-bdd/verity-bdd/verity_abilities/take_notes` — actor notes
+- `github.com/verity-bdd/verity-bdd/verity_abilities/wait` — polling and channel waits
+- `github.com/verity-bdd/verity-bdd/verity_answerable` — static value questions
+- `github.com/verity-bdd/verity-bdd/verity_expectations` — expectation factories
+- `github.com/verity-bdd/verity-bdd/verity_expectations/ensure` — assertion activities
+- `github.com/verity-bdd/verity-bdd/verity_reporting` — reporter contracts and adapters
+- `github.com/verity-bdd/verity-bdd/verity_reporting/console_reporter` — console reporter
+- `github.com/verity-bdd/verity-bdd/verity_reporting/allure_reporter` — Allure reporter
+
+`verity_abilities` is an organizational directory, not an importable production package. Implementation packages under `internal` are not public API.
+
+## More documentation
+
+- [Documentation index](docs/index.md)
+- [Creating custom abilities](docs/abilities.md)
+- [Reporting](docs/reporting.md)
+- [Satisfies examples](docs/SATISFIES_EXAMPLES.md)
+- [Working Go examples](examples/)
+
+Run the examples and test suite with:
 
 ```bash
-allure serve allure-results
-```
-
-## Working Examples
-
-The `examples/` directory contains working examples with real APIs:
-
-- `basic_test.go` - JSONPlaceholder API testing examples including basic operations, error scenarios, and multiple actors
-- `jsonplaceholder_test.go` - Additional JSONPlaceholder API examples with CRUD operations
-- `satisfies_demo_test.go` - Comprehensive examples of custom `Satisfies` expectations including go-cmp integration
-
-Run examples:
-
-```bash
-go test ./examples -v
-```
-
-For detailed `Satisfies` examples, see [docs/SATISFIES_EXAMPLES.md](docs/SATISFIES_EXAMPLES.md).
-
-## Architecture
-
-### Core Components
-
-- **github.com/verity-bdd/verity-bdd** - Core Screenplay API, testing API, and answerable helpers
-- **github.com/verity-bdd/verity-bdd/verity_abilities** - Default ability contracts and ability packages
-- **github.com/verity-bdd/verity-bdd/verity_expectations** - Expectations and assertion helpers
-- **github.com/verity-bdd/verity-bdd/verity_expectations/ensure** - Ensure activities
-- **github.com/verity-bdd/verity-bdd/verity_reporting** - Reporting contracts and adapters
-- **github.com/verity-bdd/verity-bdd/verity_reporting/console_reporter** - Console reporter
-- **github.com/verity-bdd/verity-bdd/verity_reporting/allure_reporter** - Allure reporter
-
-### Design Principles
-
-1. **Composable** - Build complex behaviors from simple components
-2. **Reusable** - Create libraries of tasks and interactions
-3. **Readable** - Tests that read like business specifications
-4. **Extensible** - Add new abilities and integrations
-5. **Type-safe** - Leverage Go's type system for safety
-
-## Advanced Usage
-
-### Custom Interactions
-
-```go
-customInteraction := core.Do("performs custom action", func(actor core.Actor) error {
-    // Your custom logic here
-    return nil
-})
-
-actor.AttemptsTo(customInteraction)
-```
-
-### Custom Questions
-
-```go
-customQuestion := core.QuestionAbout[int]("custom value", func(actor core.Actor, ctx context.Context) (int, error) {
-    // Your custom logic here
-    return 42, nil
-})
-
-ensure.That(customQuestion, expectations.Equals(42))
-```
-
-### Custom Expectations with Satisfies
-
-Create custom expectations using the `Satisfies` function for complex validation logic:
-
-```go
-// Simple custom validation
-actor.AttemptsTo(
-    ensure.That(answerable.ValueOf(age), expectations.Satisfies("is positive number", func(actual int) error {
-        if actual <= 0 {
-            return fmt.Errorf("expected positive value, but got %d", actual)
-        }
-        return nil
-    })),
-)
-
-// Advanced struct comparison with go-cmp
-actor.AttemptsTo(
-    ensure.That(answerable.ValueOf(actualUser), expectations.Satisfies("matches expected user", func(actual User) error {
-        if diff := cmp.Diff(expectedUser, actual); diff != "" {
-            return fmt.Errorf("user mismatch:\n%s", diff)
-        }
-        return nil
-    })),
-)
-
-// Complex business logic validation
-actor.AttemptsTo(
-    ensure.That(answerable.ValueOf(order), expectations.Satisfies("has valid order data", func(actual Order) error {
-        if !strings.HasPrefix(actual.ID, "ORD-") {
-            return fmt.Errorf("order ID must start with ORD-, got %s", actual.ID)
-        }
-        if actual.Amount <= 0 {
-            return fmt.Errorf("order amount must be positive, got %f", actual.Amount)
-        }
-        // Add more validation logic...
-        return nil
-    })),
-)
-```
-
-The `Satisfies` function takes:
-- A description string that appears in test failure messages
-- A validation function that returns `nil` for success or an error for failure
-
-This enables powerful, type-safe custom validations while maintaining the Screenplay Pattern's readable test structure.
-
-### Task Composition
-
-```go
-// Build complex workflows from simple tasks
-setupTask := core.Where("setup test data", setupDataAction)
-testTask := core.Where("run test scenario", testAction)
-cleanupTask := core.Where("cleanup test data", cleanupAction)
-
-actor.AttemptsTo(
-    setupTask,
-    testTask,
-    cleanupTask,
-)
-```
-
-### Multiple Actors
-
-```go
-test := verity.NewVerityTest(t, verity.Scene{})
-
-admin := test.ActorCalled("Admin").WhoCan(api.CallAnApiAt(baseURL))
-user := test.ActorCalled("RegularUser").WhoCan(api.CallAnApiAt(baseURL))
-
-// Admin creates resources
-admin.AttemptsTo(createResourceTask)
-
-// User interacts with resources
-user.AttemptsTo(accessResourceTask)
+go test ./...
 ```
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit issues and pull requests.
+Contributions are welcome. Open an issue to discuss defects or proposed changes, and submit focused pull requests with tests and updated documentation where applicable.
 
 ## License
-Apache 2.0 - see LICENSE file for details.
+
+Verity-BDD is licensed under the [Apache License 2.0](LICENSE).

--- a/core_api.go
+++ b/core_api.go
@@ -42,7 +42,7 @@ type Ability = internalabilities.Ability
 //	)
 //
 //	// Perform activities
-//	err := actor.AttemptsTo(
+//	actor.AttemptsTo(
 //		Do("creates customer order", func(ctx context.Context, a Actor) error {
 //			return createOrder(orderData).PerformAs(ctx, a)
 //		}),
@@ -83,7 +83,7 @@ type Actor = internalcore.Actor
 // Activity Lifecycle:
 //
 //  1. Actor calls AttemptsTo() with one or more activities
-//  2. Each activity's PerformAs() method is called with the actor
+//  2. Each activity's PerformAs() method is called with the context and actor
 //  3. Activity uses actor's abilities to perform its action
 //  4. Activity returns success or error
 //  5. Actor handles errors based on activity's FailureMode
@@ -108,7 +108,12 @@ type Activity = internalcore.Activity
 //		if err != nil {
 //			return fmt.Errorf("actor needs API ability: %w", err)
 //		}
-//		return ability.SendGetRequest("/users")
+//		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/users", nil)
+//		if err != nil {
+//			return err
+//		}
+//		_, err = ability.SendRequest(req, ctx)
+//		return err
 //	})
 //
 // Custom Interaction Types:
@@ -175,7 +180,7 @@ type Task = internalcore.Task
 // Creating Questions:
 //
 //	// Using QuestionAbout (convenience factory)
-//	userCount := QuestionAbout("user count", func(ctx context.Context, actor Actor) (int, error) {
+//	userCount := QuestionAbout[any]("user count", func(ctx context.Context, actor Actor) (any, error) {
 //		db, err := AbilityOf[database.DatabaseAbility](actor)
 //		if err != nil {
 //			return 0, err
@@ -202,7 +207,7 @@ type Task = internalcore.Task
 //
 //	// With expectations (recommended)
 //	actor.AttemptsTo(
-//		ensure.That(userCount, expectations.GreaterThan(0)),
+//		ensure.That(userCount, expectations.IsGreaterThan(0)),
 //		ensure.That(userName, expectations.ContainsSubstring("admin")),
 //	)
 //
@@ -258,9 +263,8 @@ type Status = internalcore.Status
 // This type determines whether test execution continues or stops
 // when an activity encounters an error.
 //
-// Default Behavior:
-//
-//	All activities use FailFast mode unless explicitly overridden.
+// Built-in interactions and tasks currently use FailFast. Custom Activity
+// implementations choose their mode by implementing FailureMode.
 type FailureMode = internalcore.FailureMode
 
 const (
@@ -295,14 +299,13 @@ const (
 	//	- Dependencies required for subsequent steps
 	//
 	// Behavior:
-	//	- Stops execution immediately on error
-	//	- Returns the first error encountered
+	//	- Records the failure with TestContext.Errorf and calls TestContext.FailNow
+	//	- AttemptsTo returns no value; failures are reported through the test context
 	//	- Subsequent activities are not executed
 	FailFast = internalcore.FailFast
 
-	// ErrorButContinue logs the error but continues with remaining activities.
-	// Use this for non-critical operations where you want to know about
-	// failures but don't want them to stop the entire test.
+	// ErrorButContinue reports the error with TestContext.Errorf, marking the
+	// test failed, but continues with remaining activities.
 	//
 	// Use Cases:
 	//	- Monitoring and metrics collection
@@ -310,13 +313,12 @@ const (
 	//	- Audit logging
 	//
 	// Behavior:
-	//	- Logs the error but continues execution
+	//	- Marks the test failed but continues execution
 	//	- Later activities continue to execute
 	ErrorButContinue = internalcore.ErrorButContinue
 
-	// Ignore completely ignores the failure and continues.
-	// Use this for truly optional operations where failure is acceptable
-	// or expected in certain scenarios.
+	// Ignore logs the failure with TestContext.Logf and continues without
+	// marking the test failed.
 	//
 	// Use Cases:
 	//	- Optional cleanup operations
@@ -324,8 +326,7 @@ const (
 	//	- Precondition checks that may legitimately fail
 	//
 	// Behavior:
-	//	- Completely ignores any errors
-	//	- Never returns errors from this activity
+	//	- Logs the error without failing the test
 	//	- Execution continues regardless of success or failure
 	Ignore = internalcore.Ignore
 )
@@ -345,11 +346,16 @@ const (
 //
 //	// Simple API call interaction
 //	sendGetRequest := Do("sends GET request to /users", func(ctx context.Context, actor Actor) error {
-//		api, err := AbilityOf[api.CallAnAPI](actor)
+//		apiAbility, err := AbilityOf[api.CallAnAPI](actor)
 //		if err != nil {
 //			return fmt.Errorf("actor needs API ability: %w", err)
 //		}
-//		return api.SendGetRequest("/users")
+//		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/users", nil)
+//		if err != nil {
+//			return err
+//		}
+//		_, err = apiAbility.SendRequest(req, ctx)
+//		return err
 //	})
 //
 //	// As part of a task
@@ -381,10 +387,7 @@ func Do(description string, perform func(context.Context, Actor) error) Interact
 //		Do("verifies user in database", verifyUser),
 //	)
 //
-//	err := actor.AttemptsTo(registerUser)
-//	if err != nil {
-//		return fmt.Errorf("test workflow failed: %w", err)
-//	}
+//	actor.AttemptsTo(registerUser)
 func TaskWhere(description string, activities ...Activity) Task {
 	return internalcore.TaskWhere(description, activities...)
 }
@@ -396,48 +399,34 @@ func TaskWhere(description string, activities ...Activity) Task {
 // Returns:
 //   - FailureMode: Always returns FailFast
 //
-// Usage:
-//
-//	actor.AttemptsTo(
-//		Do("establishes database connection", connectDB).WithFailureMode(Critical()),
-//		Do("creates user account", createUser),
-//	)
+// Interactions returned by Do do not provide a WithFailureMode method. Return
+// Critical from FailureMode on a custom Activity implementation when needed.
 func Critical() FailureMode {
 	return internalcore.Critical()
 }
 
-// NonCritical returns a failure mode that logs errors but continues.
+// NonCritical returns a failure mode that marks the test failed but continues.
 // This is a semantic function that returns ErrorButContinue mode.
 // Use this for operations that should be noted but not stop execution.
 //
 // Returns:
 //   - FailureMode: Always returns ErrorButContinue
 //
-// Usage:
-//
-//	actor.AttemptsTo(
-//		Do("main business operation", businessLogic),
-//		Do("collects usage metrics", collectMetrics).WithFailureMode(NonCritical()),
-//		Do("verifies result", verifyResult),
-//	)
+// Interactions returned by Do do not provide a WithFailureMode method. Return
+// NonCritical from FailureMode on a custom Activity implementation when needed.
 func NonCritical() FailureMode {
 	return internalcore.NonCritical()
 }
 
-// Optional returns a failure mode that ignores errors completely.
+// Optional returns a failure mode that logs errors without failing the test.
 // This is a semantic function that returns Ignore mode.
 // Use this for operations where failure is acceptable or expected.
 //
 // Returns:
 //   - FailureMode: Always returns Ignore
 //
-// Usage:
-//
-//	actor.AttemptsTo(
-//		Do("main test execution", mainTest),
-//		Do("attempts to cleanup resources", cleanup).WithFailureMode(Optional()),
-//		Do("final assertion", finalAssertion),
-//	)
+// Interactions returned by Do do not provide a WithFailureMode method. Return
+// Optional from FailureMode on a custom Activity implementation when needed.
 func Optional() FailureMode {
 	return internalcore.Optional()
 }
@@ -472,7 +461,7 @@ func AbilityName(ability Ability) string {
 //
 //	// With expectations
 //	actor.AttemptsTo(
-//		ensure.That(isHealthy, expectations.IsTrue()),
+//		ensure.That(isHealthy, expectations.Equals(true)),
 //	)
 func QuestionAbout[T any](description string, ask func(ctx context.Context, actor Actor) (T, error)) Question[T] {
 	return internalcore.QuestionAbout(description, ask)
@@ -497,7 +486,7 @@ func QuestionAbout[T any](description string, ask func(ctx context.Context, acto
 //	if err != nil {
 //		return fmt.Errorf("actor needs API ability: %w", err)
 //	}
-//	response, err := apiAbility.SendGetRequest("/users")
+//	response, err := apiAbility.SendRequest(request, ctx)
 func AbilityOf[T Ability](actor Actor) (T, error) {
 	return internalcore.AbilityOf[T](actor)
 }

--- a/docs/SATISFIES_EXAMPLES.md
+++ b/docs/SATISFIES_EXAMPLES.md
@@ -291,7 +291,7 @@ actor.AttemptsTo(
 The description you provide to `Satisfies` appears in test failure messages, making it clear what validation failed:
 
 ```
-#actor ensures that 42 (int) is positive number failed: assertion failed for '42 (int)': expected positive value, but got -5
+#actor ensures that -5 (int) is positive number failed: assertion failed for '-5 (int)': expected positive value, but got -5
 ```
 
 ## Best Practices
@@ -322,11 +322,18 @@ actor.AttemptsTo(
 `Satisfies` maintains type safety with generics:
 
 ```go
-// This will not compile - wrong type
-expectations.Satisfies("is positive", func(actual string) error { ... })
+// This complete expression will not compile: the question answers int,
+// while the expectation accepts string.
+ensure.That(
+    answerable.ValueOf(1),
+    expectations.Satisfies("is positive", func(actual string) error { return nil }),
+)
 
 // Correct type
-expectations.Satisfies("is positive", func(actual int) error { ... })
+ensure.That(
+    answerable.ValueOf(1),
+    expectations.Satisfies("is positive", func(actual int) error { return nil }),
+)
 ```
 
 ## Running Examples

--- a/docs/abilities.md
+++ b/docs/abilities.md
@@ -1,529 +1,156 @@
-# Создание собственных Abilities
+# Creating custom abilities
 
-Эта инструкция покажет, как создавать собственные Abilities для расширения возможностей Verity-BDD под ваши специфические потребности тестирования.
+An ability is a value attached to an actor with `WhoCan`. `verity.Ability` is currently an empty interface, so every Go value satisfies it. Embedding `verity.Ability` in your own interface is optional and can be useful as documentation, but the compiler does not require it.
 
-## 🎯 Что такое Ability?
+## A complete minimal pattern
 
-**Ability** (способность) - это возможность, которую Actor может использовать для взаимодействия с системой. В паттерне Screenplay, Abilities определяют **ЧТО** Actor может делать, а не **КАК** он это делает.
-
-### Примеры существующих Abilities:
-- `CallAnAPI` - выполнение HTTP-запросов
-- `ConnectToDatabase` - работа с базами данных
-- `UseFileSystem` - операции с файловой системой
-
-## 🏗️ Архитектура Ability
-
-### Базовый интерфейс
+The following custom ability, activity, and question use the current public API and signatures:
 
 ```go
-// verity/abilities/ability.go
-package abilities
-
-// Ability - маркерный интерфейс для всех способностей
-type Ability interface{}
-```
-
-### Поиск Ability в Actor
-
-```go
-// Actor находит Ability по типу
-ability, err := actor.AbilityTo(&targetAbilityType{})
-if err != nil {
-    return fmt.Errorf("actor does not have required ability: %w", err)
-}
-
-// Приведение к конкретному типу
-specificAbility := ability.(SpecificAbility)
-```
-
-## 📋 Пошаговая инструкция создания Ability
-
-### Шаг 1: Определите интерфейс Ability
-
-Создайте интерфейс, который:
-1. Наследует `abilities.Ability`
-2. Определяет методы, специфичные для вашей Ability
-
-```go
-package custom
-
-import "github.com/verity-bdd/verity-bdd/verity_abilities"
-
-// FileManagerAbility - способность для работы с файлами
-type FileManagerAbility interface {
-    abilities.Ability
-
-    // Core operations
-    ReadFile(path string) (string, error)
-    WriteFile(path string, content string) error
-    DeleteFile(path string) error
-
-    // State management
-    LastOperation() string
-    SetWorkingDirectory(dir string) error
-}
-```
-
-### Шаг 2: Создайте приватную реализацию
-
-```go
-// fileManagerAbility - приватная реализация
-type fileManagerAbility struct {
-    workingDir   string
-    lastOperation string
-}
-
-// Конструктор
-func ManageFiles() FileManagerAbility {
-    return &fileManagerAbility{
-        workingDir: ".",
-        lastOperation: "none",
-    }
-}
-
-// Методы реализации
-func (f *fileManagerAbility) ReadFile(path string) (string, error) {
-    fullPath := filepath.Join(f.workingDir, path)
-    content, err := os.ReadFile(fullPath)
-    if err != nil {
-        f.lastOperation = fmt.Sprintf("read error: %s", path)
-        return "", fmt.Errorf("failed to read file %s: %w", path, err)
-    }
-
-    f.lastOperation = fmt.Sprintf("read: %s", path)
-    return string(content), nil
-}
-
-func (f *fileManagerAbility) WriteFile(path string, content string) error {
-    fullPath := filepath.Join(f.workingDir, path)
-    err := os.WriteFile(fullPath, []byte(content), 0644)
-    if err != nil {
-        f.lastOperation = fmt.Sprintf("write error: %s", path)
-        return fmt.Errorf("failed to write file %s: %w", path, err)
-    }
-
-    f.lastOperation = fmt.Sprintf("write: %s", path)
-    return nil
-}
-
-func (f *fileManagerAbility) DeleteFile(path string) error {
-    fullPath := filepath.Join(f.workingDir, path)
-    err := os.Remove(fullPath)
-    if err != nil {
-        f.lastOperation = fmt.Sprintf("delete error: %s", path)
-        return fmt.Errorf("failed to delete file %s: %w", path, err)
-    }
-
-    f.lastOperation = fmt.Sprintf("delete: %s", path)
-    return nil
-}
-
-func (f *fileManagerAbility) LastOperation() string {
-    return f.lastOperation
-}
-
-func (f *fileManagerAbility) SetWorkingDirectory(dir string) error {
-    if !filepath.IsAbs(dir) {
-        abs, err := filepath.Abs(dir)
-        if err != nil {
-            return fmt.Errorf("failed to get absolute path: %w", err)
-        }
-        dir = abs
-    }
-
-    if _, err := os.Stat(dir); os.IsNotExist(err) {
-        return fmt.Errorf("directory does not exist: %s", dir)
-    }
-
-    f.workingDir = dir
-    return nil
-}
-```
-
-### Шаг 3: Создайте фабричные методы (опционально)
-
-Для удобства использования создайте именованные конструкторы:
-
-```go
-// Разные способы создания Ability
-func ManageFiles() FileManagerAbility {
-    return &fileManagerAbility{workingDir: "."}
-}
-
-func ManageFilesIn(directory string) FileManagerAbility {
-    return &fileManagerAbility{workingDir: directory}
-}
-
-func ManageFilesWithConfig(config FileManagerConfig) FileManagerAbility {
-    return &fileManagerAbility{
-        workingDir: config.WorkingDirectory,
-        // другие параметры конфигурации
-    }
-}
-
-// Конфигурация для сложных Ability
-type FileManagerConfig struct {
-    WorkingDirectory string
-    CreateDirs        bool
-    BackupOnDelete    bool
-}
-```
-
-### Шаг 4: Интегрируйте с Activities
-
-Создайте Activities, которые используют вашу Ability:
-
-```go
-package custom
+package files
 
 import (
-    "github.com/verity-bdd/verity-bdd"
+    "context"
+    "fmt"
+    "sync"
+
+    verity "github.com/verity-bdd/verity-bdd"
 )
 
-// ReadFileActivity - чтение файла
-type ReadFileActivity struct {
-    path string
+type Manager interface {
+    Read(path string) (string, error)
+    Write(path, content string) error
 }
 
-func ReadFile(path string) *ReadFileActivity {
-    return &ReadFileActivity{path: path}
+type memoryManager struct {
+    mu    sync.RWMutex
+    files map[string]string
 }
 
-func (r *ReadFileActivity) PerformAs(actor core.Actor) error {
-    // Получаем Ability от Actor
-    ability, err := actor.AbilityTo(&fileManagerAbility{})
-    if err != nil {
-        return fmt.Errorf("actor does not have file management ability: %w", err)
+func ManageInMemory() Manager {
+    return &memoryManager{files: make(map[string]string)}
+}
+
+func (m *memoryManager) Read(path string) (string, error) {
+    m.mu.RLock()
+    defer m.mu.RUnlock()
+    content, ok := m.files[path]
+    if !ok {
+        return "", fmt.Errorf("file %q not found", path)
     }
-
-    fileManager := ability.(FileManagerAbility)
-    _, err = fileManager.ReadFile(r.path)
-    return err
+    return content, nil
 }
 
-func (r *ReadFileActivity) Description() string {
-    return fmt.Sprintf("reads file: %s", r.path)
-}
-```
-
-### Шаг 5: Создайте Questions для проверки состояния
-
-```go
-// FileContentQuestion - вопрос о содержимом файла
-type FileContentQuestion struct {
-    path string
+func (m *memoryManager) Write(path, content string) error {
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    m.files[path] = content
+    return nil
 }
 
-func FileContent(path string) *FileContentQuestion {
-    return &FileContentQuestion{path: path}
-}
-
-func (f *FileContentQuestion) AnsweredBy(actor core.Actor) (string, error) {
-    ability, err := actor.AbilityTo(&fileManagerAbility{})
-    if err != nil {
-        return "", fmt.Errorf("actor does not have file management ability: %w", err)
-    }
-
-    fileManager := ability.(FileManagerAbility)
-    return fileManager.ReadFile(f.path)
-}
-
-func (f *FileContentQuestion) Description() string {
-    return fmt.Sprintf("content of file: %s", f.path)
-}
-```
-
-## 🔧 Использование вашей Ability
-
-### Базовое использование
-
-```go
-func TestFileOperations(t *testing.T) {
-    test := verity.NewVerityTest(t, verity.Scene{})
-
-    // Создаем Actor с нашей новой Ability
-    actor := test.ActorCalled("FileUser").WhoCan(
-        custom.ManageFilesIn("/tmp/test"),
-    )
-
-    // Используем Activities
-    err := actor.AttemptsTo(
-        custom.WriteFile("test.txt", "Hello, World!"),
-        ensure.That(custom.FileContent("test.txt"), expectations.ContainsSubstring("Hello")),
-    )
-
-    require.NoError(t, err)
-}
-```
-
-### Композиция с другими Abilities
-
-```go
-func TestAPIAndFileOperations(t *testing.T) {
-    test := verity.NewVerityTest(t, verity.Scene{})
-
-    actor := test.ActorCalled("IntegrationTester").WhoCan(
-        api.CallAnApiAt("https://api.example.com"),
-        custom.ManageFilesIn("./test-data"),
-    )
-
-    err := actor.AttemptsTo(
-        // Сначала получаем данные из API
-        api.SendGetRequest("/users/1"),
-        // Затем сохраняем их в файл
-        custom.WriteFile("user.json", api.LastResponseBody{}),
-        // Проверяем содержимое файла
-        ensure.That(custom.FileContent("user.json"), expectations.ContainsSubstring("name")),
-    )
-
-    require.NoError(t, err)
-}
-```
-
-## ⚡ Advanced Patterns
-
-### Pattern 1: Builder для сложных Activities
-
-```go
-type WriteFileActivity struct {
-    path    string
-    content string
-    mode    os.FileMode
-    backup  bool
-}
-
-func WriteFile(path string) *WriteFileActivity {
-    return &WriteFileActivity{
-        path:    path,
-        mode:    0644,
-        backup:  false,
-    }
-}
-
-func (w *WriteFileActivity) WithContent(content string) *WriteFileActivity {
-    w.content = content
-    return w
-}
-
-func (w *WriteFileActivity) WithMode(mode os.FileMode) *WriteFileActivity {
-    w.mode = mode
-    return w
-}
-
-func (w *WriteFileActivity) WithBackup() *WriteFileActivity {
-    w.backup = true
-    return w
-}
-
-// Использование:
-err := actor.AttemptsTo(
-    custom.WriteFile("config.json").
-        WithContent(configData).
-        WithMode(0600).
-        WithBackup(),
-)
-```
-
-### Pattern 2: State Management между вызовами
-
-```go
-type DatabaseConnectionAbility interface {
-    abilities.Ability
-    Connect(dsn string) error
-    Disconnect() error
-    Execute(query string, args ...interface{}) (*sql.Rows, error)
-    LastQuery() string
-    LastError() error
-}
-
-type databaseConnectionAbility struct {
-    db         *sql.DB
-    lastQuery  string
-    lastError  error
-    isConnected bool
-    mutex      sync.RWMutex
-}
-
-func (d *databaseConnectionAbility) Execute(query string, args ...interface{}) (*sql.Rows, error) {
-    d.mutex.Lock()
-    defer d.mutex.Unlock()
-
-    d.lastQuery = query
-
-    if !d.isConnected {
-        d.lastError = fmt.Errorf("not connected to database")
-        return nil, d.lastError
-    }
-
-    rows, err := d.db.Query(query, args...)
-    d.lastError = err
-    return rows, err
-}
-```
-
-### Pattern 3: Error Handling и Retry Logic
-
-```go
-type ResilientAPIAbility interface {
-    abilities.Ability
-    SendRequest(req *http.Request) (*http.Response, error)
-    WithRetryPolicy(policy RetryPolicy) ResilientAPIAbility
-    WithTimeout(timeout time.Duration) ResilientAPIAbility
-}
-
-type resilientAPIAbility struct {
-    client      *http.Client
-    retryPolicy RetryPolicy
-    timeout     time.Duration
-}
-
-func (r *resilientAPIAbility) SendRequest(req *http.Request) (*http.Response, error) {
-    var lastErr error
-
-    for attempt := 0; attempt <= r.retryPolicy.MaxRetries; attempt++ {
-        if attempt > 0 {
-            time.Sleep(r.retryPolicy.Delay(attempt))
+func Write(path, content string) verity.Activity {
+    return verity.Do("#actor writes "+path, func(ctx context.Context, actor verity.Actor) error {
+        manager, err := verity.AbilityOf[Manager](actor)
+        if err != nil {
+            return fmt.Errorf("file manager ability: %w", err)
         }
+        return manager.Write(path, content)
+    })
+}
 
-        resp, err := r.client.Do(req)
-        if err == nil {
-            return resp, nil
+func Content(path string) verity.Question[string] {
+    return verity.QuestionAbout("content of "+path, func(ctx context.Context, actor verity.Actor) (string, error) {
+        manager, err := verity.AbilityOf[Manager](actor)
+        if err != nil {
+            return "", fmt.Errorf("file manager ability: %w", err)
         }
-
-        lastErr = err
-
-        if !r.retryPolicy.ShouldRetry(err, attempt) {
-            break
-        }
-    }
-
-    return nil, fmt.Errorf("request failed after %d attempts: %w", r.retryPolicy.MaxRetries+1, lastErr)
+        return manager.Read(path)
+    })
 }
 ```
 
-## 🧪 Тестирование вашей Ability
-
-### Unit тесты для реализации
+Use it in a test:
 
 ```go
-func TestFileManagerAbility_ReadFile(t *testing.T) {
-    // Arrange
-    tempDir := t.TempDir()
-    ability := custom.ManageFilesIn(tempDir)
-    testFile := filepath.Join(tempDir, "test.txt")
-
-    // Создаем тестовый файл
-    require.NoError(t, os.WriteFile(testFile, []byte("test content"), 0644))
-
-    // Act
-    content, err := ability.ReadFile("test.txt")
-
-    // Assert
-    require.NoError(t, err)
-    assert.Equal(t, "test content", content)
-    assert.Equal(t, "read: test.txt", ability.LastOperation())
-}
-
-func TestFileManagerAbility_ReadFile_NotFound(t *testing.T) {
-    // Arrange
-    ability := custom.ManageFilesIn(t.TempDir())
-
-    // Act
-    _, err := ability.ReadFile("nonexistent.txt")
-
-    // Assert
-    require.Error(t, err)
-    assert.Contains(t, err.Error(), "failed to read file")
-    assert.Equal(t, "read error: nonexistent.txt", ability.LastOperation())
-}
-```
-
-### Интеграционные тесты с Actor
-
-```go
-func TestFileManagerIntegration(t *testing.T) {
+func TestFiles(t *testing.T) {
     test := verity.NewVerityTest(t, verity.Scene{})
+    actor := test.ActorCalled("File user").WhoCan(files.ManageInMemory())
 
-    actor := test.ActorCalled("FileTester").WhoCan(
-        custom.ManageFilesIn(t.TempDir()),
+    actor.AttemptsTo(
+        files.Write("message.txt", "hello"),
+        ensure.That(files.Content("message.txt"), expectations.Equals("hello")),
     )
+}
+```
 
-    err := actor.AttemptsTo(
-        custom.WriteFile("integration.txt", "integration test"),
-        ensure.That(custom.FileContent("integration.txt"), expectations.Equals("integration test")),
-    )
+## Required activity and question contracts
 
+A custom activity must implement all three methods:
+
+```go
+type Activity interface {
+    PerformAs(context.Context, verity.Actor) error
+    Description() string
+    FailureMode() verity.FailureMode
+}
+```
+
+Using `verity.Do` is the simplest way to create a fail-fast interaction. It accepts `func(context.Context, verity.Actor) error`. The returned `verity.Interaction` does not expose `WithFailureMode`; implement your own activity type when a different failure mode is needed.
+
+A typed question must implement:
+
+```go
+type Question[T any] interface {
+    Description() string
+    AnsweredBy(context.Context, verity.Actor) (T, error)
+}
+```
+
+`verity.QuestionAbout` supplies those methods around a callback.
+
+## Retrieving abilities
+
+Prefer the typed helper:
+
+```go
+manager, err := verity.AbilityOf[Manager](actor)
+```
+
+The lower-level `actor.AbilityTo(probe)` returns an untyped `verity.Ability` and uses the probe's type for lookup. Avoid requesting a pointer to an interface (for example, `AbilityOf[*Manager]`); request the interface itself.
+
+## Design guidance
+
+- Keep state in the ability when activities and questions need to share it.
+- Make stateful abilities safe for the concurrency model of your tests.
+- Return descriptive wrapped errors from activities and questions.
+- Keep interactions small and compose business workflows with `verity.TaskWhere`.
+- Use interfaces for replaceable external clients when it improves testing; an interface is not required merely to satisfy `verity.Ability`.
+
+## Testing a custom ability
+
+Test the domain implementation directly, then add an actor-level test to verify ability lookup, activity execution, and the question contract.
+
+```go
+func TestMemoryManager(t *testing.T) {
+    manager := files.ManageInMemory()
+    require.NoError(t, manager.Write("message.txt", "hello"))
+
+    content, err := manager.Read("message.txt")
     require.NoError(t, err)
+    require.Equal(t, "hello", content)
+}
+
+func TestFilesWithActor(t *testing.T) {
+    test := verity.NewVerityTest(t, verity.Scene{})
+    actor := test.ActorCalled("File user").WhoCan(files.ManageInMemory())
+
+    actor.AttemptsTo(
+        files.Write("message.txt", "hello"),
+        ensure.That(files.Content("message.txt"), expectations.Equals("hello")),
+    )
 }
 ```
 
-## 📋 Best Practices
+Use fakes or local test servers for external clients, cover missing-ability and domain-error paths, and run actor-level tests through `NewVerityTest` so failure handling and automatic cleanup are exercised.
 
-### ✅ Do's
-1. **Используйте интерфейсы** - отделяйте контракты от реализации
-2. **Создавайте именованные конструкторы** - для разных сценариев использования
-3. **Храните состояние** только если это необходимо между вызовами
-4. **Оборачивайте ошибки** с контекстом
-5. **Используйте RWMutex** для защиты состояния в concurrent scenarios
-6. **Пишите тесты** для каждого метода Ability
-7. **Следуйте Go naming conventions**
-
-### ❌ Don'ts
-1. **Не храните** в Ability большую mutable state
-2. **Не создавайте** глобальные переменные в Ability
-3. **Не игнорируйте** ошибки - всегда возвращайте их
-4. **Не смешивайте** concerns - одна Ability = одна ответственность
-5. **Не забывайте** про thread safety
-
-## 🎯 Примеры готовых Ability
-
-### Database Ability
-```go
-type DatabaseAbility interface {
-    abilities.Ability
-    Query(query string, args ...interface{}) (*sql.Rows, error)
-    Execute(query string, args ...interface{}) (sql.Result, error)
-    BeginTx() (*sql.Tx, error)
-}
-
-func ConnectToPostgreSQL(dsn string) DatabaseAbility {
-    // implementation
-}
-```
-
-### Redis Ability
-```go
-type RedisAbility interface {
-    abilities.Ability
-    Set(key string, value interface{}) error
-    Get(key string) (string, error)
-    Del(key string) error
-}
-
-func ConnectToRedis(addr string) RedisAbility {
-    // implementation
-}
-```
-
-### WebSocket Ability
-```go
-type WebSocketAbility interface {
-    abilities.Ability
-    Connect(url string) error
-    Send(message []byte) error
-    Receive(timeout time.Duration) ([]byte, error)
-    Close() error
-}
-```
-
----
-
-## 🚀 Следующие шаги
-
-1. **Изучите примеры** в [docs/examples/](examples/)
-2. **Используйте шаблоны** из [docs/templates/](templates/)
-3. **Посмотрите существующие Abilities** в исходном коде проекта
-4. **Изучите готовый пример** FileSystemAbility с тестами в [examples/ability/](../examples/ability/)
-
-Удачи в создании мощных и гибких тестов с помощью Verity-BDD! 🎉
-
+See [the compact template](templates/ability.md) and [current examples](examples/abilities.md).

--- a/docs/examples/abilities.md
+++ b/docs/examples/abilities.md
@@ -1,811 +1,132 @@
-# Примеры реализации Abilities
+# Custom ability examples
 
-Здесь собраны реальные примеры Abilities для различных сценариев тестирования.
+These examples focus on the Verity integration points. Database, filesystem, WebSocket, and Redis client setup is domain-specific; the same current API pattern applies to each.
 
-## 🗄️ Database Ability (PostgreSQL)
-
-Полная реализация для работы с PostgreSQL базой данных.
-
-### Интерфейс
+## Database example
 
 ```go
 package database
 
 import (
+    "context"
     "database/sql"
     "fmt"
-    _ "github.com/lib/pq"
 
-    "github.com/verity-bdd/verity-bdd/verity_abilities"
+    verity "github.com/verity-bdd/verity-bdd"
 )
 
-// DatabaseAbility - способность для работы с базами данных
-type DatabaseAbility interface {
-    abilities.Ability
-
-    // Connection management
-    Connect(dsn string) error
-    Disconnect() error
-    Ping() error
-
-    // Query operations
-    Query(query string, args ...interface{}) (*sql.Rows, error)
-    QueryRow(query string, args ...interface{}) *sql.Row
-    Execute(query string, args ...interface{}) (sql.Result, error)
-
-    // Transaction management
-    BeginTx() (*sql.Tx, error)
-
-    // State information
-    LastQuery() string
-    LastError() error
-    IsConnected() bool
-}
-```
-
-### Реализация
-
-```go
-type databaseAbility struct {
-    db         *sql.DB
-    lastQuery  string
-    lastError  error
-    dsn        string
-    mutex      sync.RWMutex
+type Ability interface {
+    ExecContext(context.Context, string, ...any) (sql.Result, error)
+    QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
-// ConnectToPostgreSQL - создает способность для подключения к PostgreSQL
-func ConnectToPostgreSQL(dsn string) DatabaseAbility {
-    return &databaseAbility{
-        dsn: dsn,
-    }
-}
-
-func (d *databaseAbility) Connect(dsn string) error {
-    d.mutex.Lock()
-    defer d.mutex.Unlock()
-
-    if dsn != "" {
-        d.dsn = dsn
-    }
-
-    db, err := sql.Open("postgres", d.dsn)
-    if err != nil {
-        d.lastError = fmt.Errorf("failed to open database: %w", err)
-        return d.lastError
-    }
-
-    // Проверяем соединение
-    if err := db.Ping(); err != nil {
-        d.lastError = fmt.Errorf("failed to ping database: %w", err)
-        db.Close()
-        return d.lastError
-    }
-
-    d.db = db
-    d.lastError = nil
-    return nil
-}
-
-func (d *databaseAbility) Query(query string, args ...interface{}) (*sql.Rows, error) {
-    d.mutex.Lock()
-    defer d.mutex.Unlock()
-
-    if d.db == nil {
-        err := fmt.Errorf("database not connected")
-        d.lastError = err
-        d.lastQuery = query
-        return nil, err
-    }
-
-    d.lastQuery = query
-    rows, err := d.db.Query(query, args...)
-    d.lastError = err
-    return rows, err
-}
-
-func (d *databaseAbility) Execute(query string, args ...interface{}) (sql.Result, error) {
-    d.mutex.Lock()
-    defer d.mutex.Unlock()
-
-    if d.db == nil {
-        err := fmt.Errorf("database not connected")
-        d.lastError = err
-        d.lastQuery = query
-        return nil, err
-    }
-
-    d.lastQuery = query
-    result, err := d.db.Exec(query, args...)
-    d.lastError = err
-    return result, err
-}
-
-func (d *databaseAbility) Disconnect() error {
-    d.mutex.Lock()
-    defer d.mutex.Unlock()
-
-    if d.db != nil {
-        err := d.db.Close()
-        d.db = nil
-        d.lastError = err
+func Execute(statement string, args ...any) verity.Activity {
+    return verity.Do("#actor executes a database statement", func(ctx context.Context, actor verity.Actor) error {
+        db, err := verity.AbilityOf[Ability](actor)
+        if err != nil {
+            return fmt.Errorf("database ability: %w", err)
+        }
+        _, err = db.ExecContext(ctx, statement, args...)
         return err
-    }
-    return nil
+    })
+}
+
+func Count(query string, args ...any) verity.Question[int] {
+    return verity.QuestionAbout("database row count", func(ctx context.Context, actor verity.Actor) (int, error) {
+        db, err := verity.AbilityOf[Ability](actor)
+        if err != nil {
+            return 0, fmt.Errorf("database ability: %w", err)
+        }
+        var count int
+        err = db.QueryRowContext(ctx, query, args...).Scan(&count)
+        return count, err
+    })
 }
 ```
 
-### Activities
-
 ```go
-// CreateTableActivity - создание таблицы
-type CreateTableActivity struct {
-    tableName string
-    schema    string
-}
-
-func CreateTable(tableName, schema string) *CreateTableActivity {
-    return &CreateTableActivity{
-        tableName: tableName,
-        schema:    schema,
-    }
-}
-
-func (c *CreateTableActivity) PerformAs(actor core.Actor) error {
-    ability, err := actor.AbilityTo(&databaseAbility{})
-    if err != nil {
-        return fmt.Errorf("actor does not have database ability: %w", err)
-    }
-
-    db := ability.(DatabaseAbility)
-    _, err = db.Execute(c.schema)
-    return err
-}
-
-func (c *CreateTableActivity) Description() string {
-    return fmt.Sprintf("creates table: %s", c.tableName)
-}
-
-// InsertDataActivity - вставка данных
-type InsertDataActivity struct {
-    table string
-    data  map[string]interface{}
-}
-
-func InsertInto(table string, data map[string]interface{}) *InsertDataActivity {
-    return &InsertDataActivity{table: table, data: data}
-}
-
-func (i *InsertDataActivity) PerformAs(actor core.Actor) error {
-    ability, err := actor.AbilityTo(&databaseAbility{})
-    if err != nil {
-        return fmt.Errorf("actor does not have database ability: %w", err)
-    }
-
-    db := ability.(DatabaseAbility)
-
-    // Build INSERT query
-    columns := make([]string, 0, len(i.data))
-    placeholders := make([]string, 0, len(i.data))
-    values := make([]interface{}, 0, len(i.data))
-
-    for column, value := range i.data {
-        columns = append(columns, column)
-        placeholders = append(placeholders, fmt.Sprintf("$%d", len(columns)))
-        values = append(values, value)
-    }
-
-    query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
-        i.table,
-        strings.Join(columns, ", "),
-        strings.Join(placeholders, ", "),
-    )
-
-    _, err = db.Execute(query, values...)
-    return err
-}
-```
-
-### Использование
-
-```go
-func TestDatabaseOperations(t *testing.T) {
+func TestDatabase(t *testing.T) {
+    db := openTestDatabase(t)
     test := verity.NewVerityTest(t, verity.Scene{})
+    actor := test.ActorCalled("DB admin").WhoCan(db)
 
-    actor := test.ActorCalled("DBAdmin").WhoCan(
-        database.ConnectToPostgreSQL("postgres://user:pass@localhost/testdb?sslmode=disable"),
+    actor.AttemptsTo(
+        database.Execute("INSERT INTO users(name) VALUES ($1)", "Alice"),
+        ensure.That(database.Count("SELECT COUNT(*) FROM users"), expectations.Equals(1)),
     )
-
-    err := actor.AttemptsTo(
-        // Подключаемся к базе
-        core.Do("connects to database", func(actor core.Actor) error {
-            ability, _ := actor.AbilityTo(&databaseAbility{})
-            return ability.(DatabaseAbility).Connect("")
-        }),
-
-        // Создаем таблицу
-        database.CreateTable("users", `
-            CREATE TABLE users (
-                id SERIAL PRIMARY KEY,
-                name VARCHAR(100) NOT NULL,
-                email VARCHAR(255) UNIQUE NOT NULL,
-                created_at TIMESTAMP DEFAULT NOW()
-            )
-        `),
-
-        // Вставляем данные
-        database.InsertInto("users", map[string]interface{}{
-            "name":  "John Doe",
-            "email": "john@example.com",
-        }),
-
-        // Проверяем результат
-        ensure.That(database.RowCount("users"), expectations.Equals(1)),
-    )
-
-    require.NoError(t, err)
-
-    // Очистка
-    cleanupActor := test.ActorCalled("DBCleaner").WhoCan(
-        database.ConnectToPostgreSQL("postgres://user:pass@localhost/testdb?sslmode=disable"),
-    )
-
-    cleanupErr := cleanupActor.AttemptsTo(
-        core.Do("connects to database", func(actor core.Actor) error {
-            ability, _ := actor.AbilityTo(&databaseAbility{})
-            return ability.(DatabaseAbility).Connect("")
-        }),
-        database.DropTable("users"),
-    )
-
-    require.NoError(t, cleanupErr)
 }
 ```
 
-## 🗂️ FileSystem Ability
-
-Расширенная версия файловой системы с backup и версионированием.
-
-### Интерфейс
+## Filesystem example
 
 ```go
 package filesystem
 
 import (
-    "io/fs"
-    "time"
+    "context"
+    "fmt"
+    "os"
+    "path/filepath"
+
+    verity "github.com/verity-bdd/verity-bdd"
 )
 
-// FileSystemAbility - расширенная способность для работы с файлами
-type FileSystemAbility interface {
-    abilities.Ability
-
-    // Basic operations
-    ReadFile(path string) ([]byte, error)
-    WriteFile(path string, data []byte, perm fs.FileMode) error
-    DeleteFile(path string) error
-    Exists(path string) bool
-
-    // Directory operations
-    CreateDir(path string, perm fs.FileMode) error
-    ListDir(path string) ([]fs.DirEntry, error)
-
-    // Advanced features
-    BackupFile(path string) (string, error)
-    RestoreFile(backupPath string) error
-    GetFileSize(path string) int64
-    GetFileModTime(path string) time.Time
-
-    // Working directory
-    SetWorkingDirectory(dir string) error
-    GetWorkingDirectory() string
-
-    // State
-    LastOperation() string
-}
-```
-
-### Реализация
-
-```go
-type fileSystemAbility struct {
-    workingDir   string
-    backupDir    string
-    lastOp       string
-    backups      map[string]string // original -> backup path
-    mutex        sync.RWMutex
+type Ability struct {
+    Root string
 }
 
-func ManageFileSystem() FileSystemAbility {
-    return &fileSystemAbility{
-        workingDir: ".",
-        backupDir:  ".backups",
-        backups:    make(map[string]string),
-    }
-}
-
-func ManageFileSystemIn(directory string) FileSystemAbility {
-    abs, _ := filepath.Abs(directory)
-    return &fileSystemAbility{
-        workingDir: abs,
-        backupDir:  filepath.Join(abs, ".backups"),
-        backups:    make(map[string]string),
-    }
-}
-
-func (f *fileSystemAbility) WriteFile(path string, data []byte, perm fs.FileMode) error {
-    f.mutex.Lock()
-    defer f.mutex.Unlock()
-
-    fullPath := filepath.Join(f.workingDir, path)
-
-    // Создаем директорию если нужно
-    if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
-        f.lastOp = fmt.Sprintf("mkdir error: %s", path)
-        return fmt.Errorf("failed to create directory: %w", err)
-    }
-
-    if err := os.WriteFile(fullPath, data, perm); err != nil {
-        f.lastOp = fmt.Sprintf("write error: %s", path)
-        return fmt.Errorf("failed to write file: %w", err)
-    }
-
-    f.lastOp = fmt.Sprintf("write: %s", path)
-    return nil
-}
-
-func (f *fileSystemAbility) BackupFile(path string) (string, error) {
-    f.mutex.Lock()
-    defer f.mutex.Unlock()
-
-    fullPath := filepath.Join(f.workingDir, path)
-
-    // Создаем backup директорию
-    if err := os.MkdirAll(f.backupDir, 0755); err != nil {
-        return "", fmt.Errorf("failed to create backup directory: %w", err)
-    }
-
-    // Генерируем имя backup файла
-    timestamp := time.Now().Format("20060102-150405")
-    backupName := fmt.Sprintf("%s_%s_%s",
-        filepath.Base(path),
-        strings.TrimSuffix(filepath.Ext(path), "."),
-        timestamp,
-    )
-    backupPath := filepath.Join(f.backupDir, backupName)
-
-    // Копируем файл
-    if err := copyFile(fullPath, backupPath); err != nil {
-        return "", fmt.Errorf("failed to backup file: %w", err)
-    }
-
-    f.backups[path] = backupPath
-    f.lastOp = fmt.Sprintf("backup: %s -> %s", path, backupPath)
-    return backupPath, nil
-}
-
-func (f *fileSystemAbility) RestoreFile(backupPath string) error {
-    f.mutex.Lock()
-    defer f.mutex.Unlock()
-
-    // Находим оригинальный путь
-    var originalPath string
-    for orig, backup := range f.backups {
-        if backup == backupPath {
-            originalPath = orig
-            break
-        }
-    }
-
-    if originalPath == "" {
-        return fmt.Errorf("backup not found: %s", backupPath)
-    }
-
-    fullPath := filepath.Join(f.workingDir, originalPath)
-
-    if err := copyFile(backupPath, fullPath); err != nil {
-        f.lastOp = fmt.Sprintf("restore error: %s", originalPath)
-        return fmt.Errorf("failed to restore file: %w", err)
-    }
-
-    f.lastOp = fmt.Sprintf("restore: %s", originalPath)
-    return nil
-}
-
-func copyFile(src, dst string) error {
-    source, err := os.Open(src)
-    if err != nil {
-        return err
-    }
-    defer source.Close()
-
-    destination, err := os.Create(dst)
-    if err != nil {
-        return err
-    }
-    defer destination.Close()
-
-    _, err = io.Copy(destination, source)
-    return err
-}
-```
-
-### Использование
-
-```go
-func TestFileSystemWithBackup(t *testing.T) {
-    test := verity.NewVerityTest(t, verity.Scene{})
-
-    tempDir := t.TempDir()
-
-    actor := test.ActorCalled("FileEditor").WhoCan(
-        filesystem.ManageFileSystemIn(tempDir),
-    )
-
-    originalContent := "original content"
-    modifiedContent := "modified content"
-
-    err := actor.AttemptsTo(
-        // Создаем оригинальный файл
-        core.Do("creates original file", func(actor core.Actor) error {
-            ability, _ := actor.AbilityTo(&fileSystemAbility{})
-            return ability.(FileSystemAbility).WriteFile(
-                "important.txt",
-                []byte(originalContent),
-                0644,
-            )
-        }),
-
-        // Делаем backup
-        filesystem.BackupUpFile("important.txt"),
-
-        // Модифицируем файл
-        core.Do("modifies file", func(actor core.Actor) error {
-            ability, _ := actor.AbilityTo(&fileSystemAbility{})
-            return ability.(FileSystemAbility).WriteFile(
-                "important.txt",
-                []byte(modifiedContent),
-                0644,
-            )
-        }),
-
-        // Проверяем модификацию
-        ensure.That(filesystem.FileContent("important.txt"), expectations.Equals(modifiedContent)),
-
-        // Восстанавливаем из backup
-        filesystem.RestoreLastBackup("important.txt"),
-
-        // Проверяем восстановление
-        ensure.That(filesystem.FileContent("important.txt"), expectations.Equals(originalContent)),
-    )
-
-    require.NoError(t, err)
-}
-```
-
-## 🔌 WebSocket Ability
-
-Способность для работы с WebSocket соединениями.
-
-### Интерфейс
-
-```go
-package websocket
-
-import (
-    "time"
-    "github.com/gorilla/websocket"
-)
-
-// WebSocketAbility - способность для работы с WebSocket
-type WebSocketAbility interface {
-    abilities.Ability
-
-    // Connection management
-    Connect(url string, header http.Header) error
-    Disconnect() error
-    IsConnected() bool
-
-    // Messaging
-    Send(message []byte) error
-    SendJSON(v interface{}) error
-    Receive(timeout time.Duration) ([]byte, error)
-    ReceiveJSON(v interface{}, timeout time.Duration) error
-
-    // State
-    LastMessage() []byte
-    ConnectionDuration() time.Duration
-    MessageCount() int
-}
-```
-
-### Реализация
-
-```go
-type webSocketAbility struct {
-    conn           *websocket.Conn
-    lastMessage    []byte
-    connectTime    time.Time
-    messageCount   int
-    mutex          sync.RWMutex
-    dialer         websocket.Dialer
-    pingInterval   time.Duration
-    pongWait       time.Duration
-}
-
-func ConnectToWebSocket() WebSocketAbility {
-    return &webSocketAbility{
-        dialer:       *websocket.DefaultDialer,
-        pingInterval: 30 * time.Second,
-        pongWait:     60 * time.Second,
-    }
-}
-
-func ConnectToWebSocketWithTimeout(timeout time.Duration) WebSocketAbility {
-    dialer := websocket.DefaultDialer
-    dialer.HandshakeTimeout = timeout
-
-    return &webSocketAbility{
-        dialer:       *dialer,
-        pingInterval: 30 * time.Second,
-        pongWait:     60 * time.Second,
-    }
-}
-
-func (w *webSocketAbility) Connect(url string, header http.Header) error {
-    w.mutex.Lock()
-    defer w.mutex.Unlock()
-
-    conn, resp, err := w.dialer.Dial(url, header)
-    if err != nil {
-        return fmt.Errorf("failed to connect to websocket: %w", err)
-    }
-
-    if resp != nil && resp.Body != nil {
-        resp.Body.Close()
-    }
-
-    w.conn = conn
-    w.connectTime = time.Now()
-    w.messageCount = 0
-
-    // Запускаем ping/pong handler
-    go w.startPingPong()
-
-    return nil
-}
-
-func (w *webSocketAbility) Send(message []byte) error {
-    w.mutex.RLock()
-    defer w.mutex.RUnlock()
-
-    if w.conn == nil {
-        return fmt.Errorf("not connected to websocket")
-    }
-
-    err := w.conn.WriteMessage(websocket.TextMessage, message)
-    if err == nil {
-        w.messageCount++
-    }
-    return err
-}
-
-func (w *webSocketAbility) Receive(timeout time.Duration) ([]byte, error) {
-    w.mutex.Lock()
-    defer w.mutex.Unlock()
-
-    if w.conn == nil {
-        return nil, fmt.Errorf("not connected to websocket")
-    }
-
-    // Set read deadline
-    if timeout > 0 {
-        err := w.conn.SetReadDeadline(time.Now().Add(timeout))
-        if err != nil {
-            return nil, fmt.Errorf("failed to set read deadline: %w", err)
-        }
-    }
-
-    messageType, message, err := w.conn.ReadMessage()
-    if err != nil {
-        return nil, fmt.Errorf("failed to read message: %w", err)
-    }
-
-    if messageType == websocket.TextMessage {
-        w.lastMessage = message
-        w.messageCount++
-    }
-
-    return message, nil
-}
-
-func (w *webSocketAbility) startPingPong() {
-    ticker := time.NewTicker(w.pingInterval)
-    defer ticker.Stop()
-
-    for {
-        select {
-        case <-ticker.C:
-            w.mutex.RLock()
-            conn := w.conn
-            w.mutex.RUnlock()
-
-            if conn == nil {
-                return
-            }
-
-            if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
-                conn.Close()
-                return
-            }
-        }
-    }
-}
-```
-
-### Использование
-
-```go
-func TestWebSocketChat(t *testing.T) {
-    // Запускаем тестовый WebSocket сервер
-    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        upgrader := websocket.Upgrader{}
-        conn, _ := upgrader.Upgrade(w, r, nil)
-
-        defer conn.Close()
-
-        for {
-            messageType, message, err := conn.ReadMessage()
-            if err != nil {
-                break
-            }
-
-            // Echo message back
-            conn.WriteMessage(messageType, message)
-        }
-    }))
-    defer server.Close()
-
-    // Конвертируем HTTP URL в WebSocket URL
-    wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
-
-    actor := test.ActorCalled("WebSocketClient").WhoCan(
-        websocket.ConnectToWebSocket(),
-    )
-
-    err := actor.AttemptsTo(
-        // Подключаемся к WebSocket
-        core.Do("connects to websocket", func(actor core.Actor) error {
-            ability, _ := actor.AbilityTo(&webSocketAbility{})
-            return ability.(WebSocketAbility).Connect(wsURL, nil)
-        }),
-
-        // Отправляем сообщение
-        core.Do("sends message", func(actor core.Actor) error {
-            ability, _ := actor.AbilityTo(&webSocketAbility{})
-            return ability.(WebSocketAbility).Send([]byte("Hello WebSocket!"))
-        }),
-
-        // Получаем ответ
-        core.Do("receives response", func(actor core.Actor) error {
-            ability, _ := actor.AbilityTo(&webSocketAbility{})
-            _, err := ability.(WebSocketAbility).Receive(5 * time.Second)
+func WriteFile(path string, content []byte) verity.Activity {
+    return verity.Do("#actor writes "+path, func(ctx context.Context, actor verity.Actor) error {
+        if err := ctx.Err(); err != nil {
             return err
-        }),
+        }
+        fs, err := verity.AbilityOf[*Ability](actor)
+        if err != nil {
+            return fmt.Errorf("filesystem ability: %w", err)
+        }
+        return os.WriteFile(filepath.Join(fs.Root, path), content, 0o600)
+    })
+}
 
-        // Проверяем полученное сообщение
-        ensure.That(websocket.LastMessage(), expectations.Equals([]byte("Hello WebSocket!"))),
-        ensure.That(websocket.MessageCount(), expectations.Equals(2)), // отправлено + получено
-    )
-
-    require.NoError(t, err)
+func FileContent(path string) verity.Question[string] {
+    return verity.QuestionAbout("content of "+path, func(ctx context.Context, actor verity.Actor) (string, error) {
+        if err := ctx.Err(); err != nil {
+            return "", err
+        }
+        fs, err := verity.AbilityOf[*Ability](actor)
+        if err != nil {
+            return "", fmt.Errorf("filesystem ability: %w", err)
+        }
+        data, err := os.ReadFile(filepath.Join(fs.Root, path))
+        return string(data), err
+    })
 }
 ```
 
-## 📊 Redis Ability
-
-Способность для работы с Redis.
-
-### Интерфейс
-
 ```go
-package redis
-
-import "github.com/go-redis/redis/v8"
-
-// RedisAbility - способность для работы с Redis
-type RedisAbility interface {
-    abilities.Ability
-
-    // Connection
-    Connect(addr string, options *redis.Options) error
-    Disconnect() error
-    Ping() error
-
-    // Basic operations
-    Set(key string, value interface{}, expiration time.Duration) error
-    Get(key string) (string, error)
-    Del(keys ...string) error
-    Exists(keys ...string) (int64, error)
-
-    // Hash operations
-    HSet(key string, values ...interface{}) error
-    HGet(key, field string) (string, error)
-    HGetAll(key string) (map[string]string, error)
-
-    // List operations
-    LPush(key string, values ...interface{}) error
-    RPop(key string) (string, error)
-    LRange(key string, start, stop int64) ([]string, error)
-
-    // State
-    LastCommand() string
-    ConnectionInfo() string
-}
-```
-
-### Пример использования
-
-```go
-func TestRedisOperations(t *testing.T) {
+func TestFilesystem(t *testing.T) {
     test := verity.NewVerityTest(t, verity.Scene{})
-
-    // Предполагаем, что у вас запущен Redis на localhost:6379
-    actor := test.ActorCalled("RedisUser").WhoCan(
-        redis.ConnectToRedis("localhost:6379"),
+    actor := test.ActorCalled("File editor").WhoCan(
+        &filesystem.Ability{Root: t.TempDir()},
     )
 
-    err := actor.AttemptsTo(
-        // Подключаемся к Redis
-        core.Do("connects to redis", func(actor core.Actor) error {
-            ability, _ := actor.AbilityTo(&redisAbility{})
-            return ability.(RedisAbility).Connect("", &redis.Options{
-                Addr: "localhost:6379",
-            })
-        }),
-
-        // Устанавливаем значение
-        core.Do("sets key-value", func(actor core.Actor) error {
-            ability, _ := actor.AbilityTo(&redisAbility{})
-            return ability.(RedisAbility).Set("test:key", "test-value", 0)
-        }),
-
-        // Получаем значение
-        core.Do("gets value", func(actor core.Actor) error {
-            ability, _ := actor.AbilityTo(&redisAbility{})
-            val, err := ability.(RedisAbility).Get("test:key")
-            if err != nil {
-                return err
-            }
-            // Сохраняем значение для проверки
-            return nil
-        }),
-
-        // Проверяем существование ключа
-        ensure.That(redis.KeyExists("test:key"), expectations.IsTrue()),
-        ensure.That(redis.StringValue("test:key"), expectations.Equals("test-value")),
-
-        // Удаляем ключ
-        core.Do("deletes key", func(actor core.Actor) error {
-            ability, _ := actor.AbilityTo(&redisAbility{})
-            return ability.(RedisAbility).Del("test:key")
-        }),
-
-        // Проверяем удаление
-        ensure.That(redis.KeyExists("test:key"), expectations.IsFalse()),
+    actor.AttemptsTo(
+        filesystem.WriteFile("message.txt", []byte("hello")),
+        ensure.That(filesystem.FileContent("message.txt"), expectations.Equals("hello")),
     )
-
-    require.NoError(t, err)
 }
 ```
 
----
+## Protocol client pattern
 
-Эти примеры показывают различные подходы к созданию Abilities:
+For WebSocket, Redis, message-bus, or other clients:
 
-1. **Database Ability** - классический пример с connection management
-2. **FileSystem Ability** - продвинутая версия с backup функциями
-3. **WebSocket Ability** - работа с real-time коммуникациями
-4. **Redis Ability** - интеграция с популярным in-memory storage
+1. Store the connected client or a narrow client interface as the actor's ability.
+2. Create interactions with `verity.Do(description, func(context.Context, verity.Actor) error)`.
+3. Retrieve the client with `verity.AbilityOf[ClientContract](actor)`.
+4. Create state questions with `verity.QuestionAbout`.
+5. Compose operations with `verity.TaskWhere` when they represent one business task.
 
-Каждый пример следует паттернам, описанным в основной [инструкции по созданию Abilities](../abilities.md), и может быть адаптирован под ваши конкретные нужды.
+For asynchronous behavior, combine the custom question with `wait.Until(...)`, or wait for a channel with `wait.UntilReceived(...)`.
+
+`actor.AttemptsTo` returns no value. Activity failures are reported through the `TestContext`, so examples should not use `err := actor.AttemptsTo(...)` or `require.NoError` around it.

--- a/docs/examples/notes.md
+++ b/docs/examples/notes.md
@@ -1,28 +1,28 @@
-# Notes (заметки актора)
+# Notes (actor notepad)
 
-Минимальный пример использования заметок:
+The `take_notes` package stores values on an actor and exposes them as questions.
 
 ```go
-package examples
+package example
 
 import (
     "testing"
 
+    verity "github.com/verity-bdd/verity-bdd"
     "github.com/verity-bdd/verity-bdd/verity_abilities/take_notes"
-    veritytesting "github.com/verity-bdd/verity-bdd"
 )
 
 func TestNotesExample(t *testing.T) {
-    test := veritytesting.NewVerityTest(t, veritytesting.Scene{})
+    test := verity.NewVerityTest(t, verity.Scene{})
     actor := test.ActorCalled("Nina").WhoCan(take_notes.UsingEmptyNotepad())
 
     actor.AttemptsTo(
         take_notes.TakeNoteOf("Bearer abc123").As("auth token"),
     )
 
-    token, ok := take_notes.Note[string]("auth token").AnsweredBy(actor)
-    if !ok {
-        t.Fatalf("note not found")
+    token, err := take_notes.Note[string]("auth token").AnsweredBy(test.Context(), actor)
+    if err != nil {
+        t.Fatal(err)
     }
     if token != "Bearer abc123" {
         t.Fatalf("unexpected token: %s", token)
@@ -30,8 +30,10 @@ func TestNotesExample(t *testing.T) {
 }
 ```
 
-Что происходит:
-- `UsingEmptyNotepad()` добавляет ability хранения заметок актору.
-- `Using(NotepadWith(...))` позволяет задать стартовые заметки, например имя актора и роль.
-- `TakeNoteOf(...).As("auth token")` записывает значение и создаёт шаг в отчёте вида `Nina takes note "auth token"`.
-- `Note[string]("auth token")` безопасно читает заметку с проверкой типа.
+- `UsingEmptyNotepad()` creates the ability.
+- `Using(notepad)` attaches an existing `*NoteBook`.
+- `TakeNoteOf(value).As(key)` creates an activity.
+- `Note[T](key)` creates a typed question with `AnsweredBy(context.Context, verity.Actor) (T, error)`.
+- `NoteValue(key)` creates an untyped `Question[any]`.
+
+At test shutdown, actor notes are serialized into the built-in test-level `notes` reporting attachment. The current activity pipeline does not produce step-level attachments.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Welcome to the comprehensive documentation for Verity-BDD - a Screenplay Pattern
 
 ### 🚀 Getting Started
 - [**Main README**](../README.md) - Quick start guide and overview
-- [**Core Concepts**](#core-concepts) - Understanding Screenplay Pattern basics
+- [**Core Concepts**](../README.md#core-api) - Understanding Screenplay Pattern basics
 
 ### 🛠️ Developer Guides
 - [**Creating Custom Abilities**](abilities.md) - Complete guide to creating your own abilities
@@ -14,7 +14,7 @@ Welcome to the comprehensive documentation for Verity-BDD - a Screenplay Pattern
 - [**Templates**](templates/) - Ready-to-use templates for common tasks
 
 ### 🔧 Advanced Topics
-- [**API Testing**](../README.md#api-testing) - HTTP API testing capabilities
+- [**API Testing**](../README.md#http-api-testing) - HTTP API testing capabilities
 - [**Task Composition**](../README.md#task-composition) - Building complex workflows
 - [**Multiple Actors**](../README.md#multiple-actors) - Working with different test personas
 
@@ -49,11 +49,13 @@ apiAbility := api.CallAnApiAt("https://api.example.com")
 ### Activities
 Activities represent actions that actors perform:
 ```go
-err := actor.AttemptsTo(
+actor.AttemptsTo(
     api.SendGetRequest("/users"),
     ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
 )
 ```
+
+`AttemptsTo` reports failures through the test context and returns no value.
 
 ## 🚀 Quick Start
 

--- a/docs/reporting.md
+++ b/docs/reporting.md
@@ -1,316 +1,99 @@
-# Console Reporting
+# Reporting
 
-Verity-BDD предоставляет мощную систему консольного репортинга для визуализации результатов тестирования в реальном времени.
+Verity-BDD reports test lifecycle and activity events through `verity_reporting.Reporter`.
 
-## Overview
+## Default console reporter
 
-ConsoleReporter автоматически отображает информацию о выполнении тестов, включая:
-- Статусы тестов с emoji индикаторами
-- Время выполнения
-- Детали ошибок и проваленных ожиданий
-- Возможность записи вывода в файл
+`verity.NewVerityTest(t, scene)` uses a console reporter unless `scene.Reporter` is set. A typical test prints one test-start line, one line for each **completed** activity, and one test-finish line:
 
-## Basic Usage
-
-### Автоматическая интеграция с TestContext
-
-```go
-func TestAPITesting(t *testing.T) {
-    test := verity.NewVerityTest(t, verity.Scene{})
-
-    actor := test.ActorCalled("APITester").WhoCan(api.CallAnApiAt("https://jsonplaceholder.typicode.com"))
-
-    actor.AttemptsTo(
-        api.SendGetRequest("/posts"),
-        ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
-    )
-}
-```
-
-Вывод в консоль:
-```
+```text
 🚀 Starting: TestAPITesting
-  🔄 Sends GET request to /posts
-  ✅ Sends GET request to /posts (0.21s)
-  🔄 Ensures that the last response status code equals 200
-  ✅ Ensures that the last response status code equals 200 (0.00s)
+  ✅ APITester sends GET request to /posts (0.21s)
+  ✅ APITester ensures that the last response status code equals 200 (0.00s)
 ✅ TestAPITesting: PASSED (0.26s)
 ```
 
-### Ручная настройка репортера
+`ConsoleReporter.OnStepStart` tracks nesting but emits no separate start line. In particular, current output does not include `🔄` lines.
+
+To select the reporter explicitly or redirect output:
 
 ```go
-import (
-    "github.com/verity-bdd/verity-bdd/verity_reporting/console_reporter"
-    verity "github.com/verity-bdd/verity-bdd"
-)
-
 func TestCustomReporting(t *testing.T) {
     reporter := console_reporter.NewConsoleReporter()
+    reporter.SetOutput(os.Stdout)
 
-    test := verity.NewVerityTestWithReporter(t, reporter)
+    test := verity.NewVerityTestWithReporter(
+        context.Background(),
+        t,
+        reporter,
+    )
 
-    // ... тестовый код
+    actor := test.ActorCalled("API tester").WhoCan(
+        api.CallAnApiAt("https://api.example.com"),
+    )
+    actor.AttemptsTo(api.SendGetRequest("/health"))
 }
 ```
 
-## Custom Reporter Configuration
-
-## Allure Reporter
-
-Для CI и rich-отчетов можно использовать нативный Allure-репортер.
+`NewVerityTestWithReporter` requires `(context.Context, verity.TestContext, verity_reporting.Reporter)`. Alternatively, configure both values in a scene:
 
 ```go
-import (
-    "context"
+test := verity.NewVerityTest(t, verity.Scene{
+    Context:  ctx,
+    Reporter: reporter,
+})
+```
 
-    "github.com/verity-bdd/verity-bdd/verity_reporting/allure_reporter"
-    verity "github.com/verity-bdd/verity-bdd"
-)
+Each test should create its own reporter instance. `ConsoleReporter` synchronizes its state, but sharing one reporter across simultaneously running tests would also share its current-test and indentation state.
 
+## Reporter contract
+
+A custom reporter implements:
+
+```go
+type Reporter interface {
+    OnTestStart(testName string)
+    OnTestFinish(result verity_reporting.TestResult)
+    OnStepStart(stepDescription string)
+    OnStepFinish(stepResult verity_reporting.TestResult)
+    SetOutput(io.Writer)
+}
+```
+
+Reporter callback results expose `Name`, `Status`, duration in seconds, an error, and attachments. These `verity_reporting.TestResult` and `verity_reporting.Status` types are distinct from the root `verity.TestResult` and `verity.Status` core-state types.
+
+`verity_reporting.NewTestRunnerAdapter` wraps a reporter. `NewActivityTracker` and `NewActivityTrackerWithActor` can be used by integrations that need to emit a start/finish pair manually. When an actor name is supplied, a leading `#actor ` placeholder in the activity description is replaced with that name.
+
+## Attachments: current limitation
+
+The reporting contract and Allure reporter support attachments supplied in a `TestResult`. However, the normal actor execution path currently calls the activity tracker without attachments. There is no public activity API for collecting or forwarding step-level attachments, so `OnStepFinish` receives no produced attachments during normal Verity execution.
+
+During test shutdown, Verity serializes actor notes into a single test-level attachment named `notes` with content type `application/json` when notes exist. This attachment is passed to `OnTestFinish`.
+
+Do not describe activities or custom attachment sources as operational until the execution pipeline exposes and forwards them.
+
+## Allure reporter
+
+```go
 func TestWithAllure(t *testing.T) {
     reporter := allure_reporter.NewAllureReporterWithDir("allure-results")
-
-    test := verity.NewVerityTest(t, verity.Scene{
-        Context:  context.Background(),
-        Reporter: reporter,
-    })
+    test := verity.NewVerityTestWithReporter(context.Background(), t, reporter)
 
     actor := test.ActorCalled("Tester")
     actor.AttemptsTo(
-        // ... активности
+        verity.Do("performs an action", func(context.Context, verity.Actor) error {
+            return nil
+        }),
     )
 }
 ```
 
-Репортер сохраняет:
-- `*-result.json` с test status и шагами
-- файлы вложений (`source`) для test-level и step-level attachments
+The reporter writes `*-result.json` files, nested step data, and any attachments actually provided by callbacks. With the current built-in execution path, this means test-level notes can be persisted, while normal step-level attachments are empty.
 
-Локальный просмотр отчета:
+View results with an installed Allure CLI:
 
 ```bash
 allure serve allure-results
 ```
 
-### Настройка вывода в файл
-
-```go
-import (
-    "os"
-    "github.com/verity-bdd/verity-bdd/verity_reporting/console_reporter"
-    verity "github.com/verity-bdd/verity-bdd"
-)
-
-reporter := console_reporter.NewConsoleReporter()
-
-// Создаем файл для вывода
-file, err := os.Create("test-results.txt")
-if err != nil {
-    log.Fatal(err)
-}
-defer file.Close()
-
-// Настраиваем репортер на запись в файл
-reporter.SetOutput(file)
-
-test := verity.NewVerityTestWithReporter(t, reporter)
-
-// ... тестовый код
-```
-
-### Методы управления
-
-```go
-import (
-    "os"
-    "github.com/verity-bdd/verity-bdd/verity_reporting/console_reporter"
-)
-
-reporter := console_reporter.NewConsoleReporter()
-
-// Установка вывода (файл или консоль)
-reporter.SetOutput(os.Stdout)  // Консольный вывод
-reporter.SetOutput(file)      // Вывод в файл
-```
-
-## File Output
-
-ConsoleReporter может записывать вывод в файл для последующего анализа:
-
-```go
-import (
-    "os"
-    "github.com/verity-bdd/verity-bdd/verity_reporting/console_reporter"
-    verity "github.com/verity-bdd/verity-bdd"
-)
-
-// Создаем файл для вывода
-file, err := os.Create("test-results.txt")
-if err != nil {
-    t.Fatalf("Failed to create output file: %v", err)
-}
-defer file.Close()
-
-// Создаем репортер с выводом в файл
-reporter := console_reporter.NewConsoleReporter()
-reporter.SetOutput(file)
-
-test := verity.NewVerityTestWithReporter(t, reporter)
-
-// ... тестовый код
-```
-
-Файл будет содержать полный вывод тестов в том же формате, что и консоль.
-
-## Output Format
-
-### Статусы тестов
-
-| Статус | Emoji | Описание |
-|--------|-------|----------|
-| ✅ | ✅ | Тест успешно пройден |
-| ❌ | ❌ | Тест провален |
-| ⚠️ | ⚠️ | Предупреждение (неиспользованный actor) |
-
-### Формат вывода
-
-```
-✅ TestName (duration)
-❌ TestName (duration)
-   Error: error message
-   Stack trace: stack information
-⚠️ TestName (duration)
-   Warning: warning message
-```
-
-### Пример полного вывода
-
-```
-🚀 Starting: TestAPITesting
-  🔄 Sends GET request to /posts
-  ✅ Sends GET request to /posts (0.21s)
-  🔄 Ensures that the last response status code equals 200
-  ✅ Ensures that the last response status code equals 200 (0.00s)
-✅ TestAPITesting: PASSED (0.26s)
-
-🚀 Starting: TestFailedExpectation
-  🔄 Sends GET request to /posts
-  ❌ Sends GET request to /posts (0.15s)
-     Error: Expected status code to equal 200, but got 404
-❌ TestFailedExpectation: FAILED (0.15s)
-```
-
-## Integration Information
-
-### Совместимость с TestContext API
-
-ConsoleReporter автоматически интегрирован с TestContext API:
-
-```go
-test := verity.NewVerityTest(t, verity.Scene{})  // Автоматически использует ConsoleReporter
-```
-
-### Интеграция с VerityTest
-
-```go
-import (
-    "github.com/verity-bdd/verity-bdd/verity_reporting/console_reporter"
-    verity "github.com/verity-bdd/verity-bdd"
-)
-
-test := verity.NewVerityTestWithReporter(t, customReporter)
-```
-
-### Обработка ошибок
-
-Репортер автоматически:
-- Логирует ошибки записи в файл
-- Обрабатывает проблемы с доступом к файловой системе
-- Предоставляет информативные сообщения об ошибках
-
-### Потокобезопасность
-
-ConsoleReporter потокобезопасен и может использоваться в параллельных тестах. Каждая тестовая сессия создает изолированный репортер.
-
-## Migration from Legacy Testing
-
-### Старый подход (ручная обработка ошибок)
-
-```go
-func TestOldStyle(t *testing.T) {
-    test := verity.NewVerityTest(t, verity.Scene{})
-
-    actor := test.ActorCalled("Tester").WhoCan(api.CallAnApiAt("https://api.example.com"))
-
-    err := actor.AttemptsTo(
-        api.SendGetRequest("/users"),
-        ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
-    )
-    if err != nil {
-        t.Errorf("Test failed: %v", err)
-    }
-}
-```
-
-### Новый подход (автоматический репортинг)
-
-```go
-func TestNewStyle(t *testing.T) {
-    test := verity.NewVerityTest(t, verity.Scene{})
-
-    actor := test.ActorCalled("Tester").WhoCan(api.CallAnApiAt("https://api.example.com"))
-
-    actor.AttemptsTo(
-        api.SendGetRequest("/users"),
-        ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
-    )
-    // Статус и ошибки автоматически отображаются в консоли
-}
-```
-
-## Best Practices
-
-1. **Используйте TestContext API** для автоматического репортинга
-2. **Настраивайте файловый вывод** для CI/CD пайплайнов
-3. **Используйте descripting имена** для акторов для лучшей читаемости
-5. **Настройте quiet mode** для CI сред, где важен только файловый вывод
-
-## Troubleshooting
-
-### Файл не создается
-
-```go
-err := reporter.EnableFileOutput("results.txt")
-if err != nil {
-    // Проверьте права доступа и директорию
-    log.Printf("Failed to create file: %v", err)
-}
-```
-
-### Нет вывода в консоли
-
-Убедитесь, что репортер настроен на вывод в консоль:
-```go
-import (
-    "os"
-    "github.com/verity-bdd/verity-bdd/verity_reporting/console_reporter"
-)
-
-reporter := console_reporter.NewConsoleReporter()
-reporter.SetOutput(os.Stdout)  // Явный вывод в консоль
-```
-
-### Проблемы с параллельными тестами
-
-Каждый тест должен создавать собственный TestContext:
-```go
-import (
-    verity "github.com/verity-bdd/verity-bdd"
-)
-
-func TestParallel1(t *testing.T) {
-    test := verity.NewVerityTest(t, verity.Scene{})
-    // ... тестовый код
-}
-```
+`AllureReporter.SetOutput` is intentionally a no-op because output is written to the configured results directory.

--- a/docs/templates/ability.md
+++ b/docs/templates/ability.md
@@ -1,528 +1,135 @@
-# Шаблон для создания новой Ability
+# Custom ability template
 
-Используйте этот шаблон как основу для создания собственных Abilities в Verity-BDD.
+This compact template uses the current root API. Replace the example operations with your domain behavior.
 
-## 📋 Чек-лист перед началом
+## Plan the ability
 
-- [ ] Определите основную цель Ability (что она делает?)
-- [ ] Продумайте интерфейс (какие методы нужны?)
-- [ ] Определите, будет ли Ability хранить состояние
-- [ ] Решите, нужны ли фабричные методы
-- [ ] Продумайте, какие Activities и Questions понадобятся
+- [ ] Define the single external capability or domain responsibility.
+- [ ] Choose the smallest contract needed by activities and questions.
+- [ ] Decide whether state is shared and how concurrent access is protected.
+- [ ] List the activities, questions, and error cases the package must expose.
 
-## 🏗️ Структура файлов
+## Suggested file layout
 
-```
-verity/abilities/
-├── your_ability/
-│   ├── ability.go           # Интерфейс и основные типы
-│   ├── implementation.go    # Реализация Ability
-│   ├── activities.go        # Activities для использования Ability
-│   ├── questions.go         # Questions для проверки состояния
-│   └── builders.go          # Builder patterns и фабричные методы
-└── your_ability_test.go     # Тесты
+```text
+yourability/
+├── ability.go       # contract, implementation, and constructors
+├── activities.go    # actor actions
+├── questions.go     # observable state
+└── ability_test.go  # direct and actor-level tests
 ```
 
----
-
-## 📝 Шаблон кода
-
-### 1. Интерфейс (ability.go)
+Small abilities can keep these parts in one file; split them only when it improves navigation.
 
 ```go
-package your_ability
+package yourability
 
 import (
+    "context"
     "fmt"
-    "sync"
 
-    "github.com/verity-bdd/verity-bdd/verity_abilities"
+    verity "github.com/verity-bdd/verity-bdd"
 )
 
-// YourAbilityName - способность для [краткое описание]
-type YourAbilityName interface {
-    abilities.Ability
-
-    // Основные операции (замените на ваши методы)
-    DoSomething(param string) error
-    GetSomething() (string, error)
-
-    // Управление состоянием (если нужно)
-    SetConfig(config Config) error
-    GetStatus() string
-
-    // История операций (опционально)
-    LastOperation() string
-    LastError() error
+// Ability is the domain contract stored on an actor.
+type Ability interface {
+    Execute(context.Context, string) error
+    Result() string
 }
 
-// Config - конфигурация для Ability (опционально)
-type Config struct {
-    // Параметры конфигурации
-    Endpoint    string
-    Timeout     time.Duration
-    RetryPolicy RetryPolicy
-
-    // Другие параметры...
+type ability struct {
+    result string
 }
 
-// RetryPolicy - политика повторных попыток (опционально)
-type RetryPolicy struct {
-    MaxRetries int
-    Delay      time.Duration
-}
-```
-
-### 2. Реализация (implementation.go)
-
-```go
-package your_ability
-
-import (
-    "fmt"
-    "sync"
-    "time"
-)
-
-// yourAbilityName - приватная реализация
-type yourAbilityName struct {
-    // Конфигурация
-    config Config
-
-    // Состояние
-    lastOperation string
-    lastError     error
-    isConnected   bool
-
-    // Ресурсы
-    client SomeClient // замените на ваш тип клиента
-
-    // Thread safety
-    mutex sync.RWMutex
+func New() Ability {
+    return &ability{}
 }
 
-// ====================
-// Фабричные методы
-// ====================
-
-// NewYourAbility - базовый конструктор
-func NewYourAbility() YourAbilityName {
-    return &yourAbilityName{
-        config: Config{
-            Timeout: 30 * time.Second,
-        },
-        lastOperation: "none",
-    }
-}
-
-// NewYourAbilityWithConfig - конструктор с конфигурацией
-func NewYourAbilityWithConfig(config Config) YourAbilityName {
-    return &yourAbilityName{
-        config:        config,
-        lastOperation: "none",
-    }
-}
-
-// WithEndpoint - устанавливает endpoint (builder pattern)
-func WithEndpoint(endpoint string) YourAbilityName {
-    return &yourAbilityName{
-        config: Config{
-            Endpoint: endpoint,
-            Timeout:  30 * time.Second,
-        },
-        lastOperation: "none",
-    }
-}
-
-// ====================
-// Основные методы
-// ====================
-
-func (y *yourAbilityName) DoSomething(param string) error {
-    y.mutex.Lock()
-    defer y.mutex.Unlock()
-
-    // Валидация состояния
-    if !y.isConnected {
-        err := fmt.Errorf("not connected")
-        y.lastError = err
-        y.lastOperation = "do_something_error"
+func (a *ability) Execute(ctx context.Context, input string) error {
+    if err := ctx.Err(); err != nil {
         return err
     }
-
-    // Логика выполнения операции
-    if err := y.validateParam(param); err != nil {
-        y.lastError = fmt.Errorf("validation failed: %w", err)
-        y.lastOperation = "do_something_validation_error"
-        return y.lastError
-    }
-
-    // Выполнение основной операции
-    result, err := y.client.DoSomething(param)
-    if err != nil {
-        y.lastError = fmt.Errorf("operation failed: %w", err)
-        y.lastOperation = "do_something_failed"
-        return y.lastError
-    }
-
-    // Успешное завершение
-    y.lastOperation = fmt.Sprintf("do_something: %s", param)
-    y.lastError = nil
-
-    // Сохраняем результат если нужно
-    // y.lastResult = result
-
+    a.result = input
     return nil
 }
 
-func (y *yourAbilityName) GetSomething() (string, error) {
-    y.mutex.RLock()
-    defer y.mutex.RUnlock()
+func (a *ability) Result() string { return a.result }
 
-    if !y.isConnected {
-        return "", fmt.Errorf("not connected")
-    }
-
-    result, err := y.client.GetSomething()
-    if err != nil {
-        y.lastError = fmt.Errorf("get operation failed: %w", err)
-        return "", y.lastError
-    }
-
-    y.lastOperation = "get_something"
-    return result, nil
+// Execute creates a fail-fast interaction.
+func Execute(input string) verity.Activity {
+    return verity.Do("#actor executes an operation", func(ctx context.Context, actor verity.Actor) error {
+        a, err := verity.AbilityOf[Ability](actor)
+        if err != nil {
+            return fmt.Errorf("your ability: %w", err)
+        }
+        return a.Execute(ctx, input)
+    })
 }
 
-// ====================
-// Управление состоянием
-// ====================
-
-func (y *yourAbilityName) SetConfig(config Config) error {
-    y.mutex.Lock()
-    defer y.mutex.Unlock()
-
-    // Валидация конфигурации
-    if err := y.validateConfig(config); err != nil {
-        y.lastError = fmt.Errorf("invalid config: %w", err)
-        return y.lastError
-    }
-
-    y.config = config
-    y.lastOperation = "config_updated"
-    return nil
-}
-
-func (y *yourAbilityName) GetStatus() string {
-    y.mutex.RLock()
-    defer y.mutex.RUnlock()
-
-    if y.isConnected {
-        return fmt.Sprintf("connected to %s", y.config.Endpoint)
-    }
-    return "disconnected"
-}
-
-// ====================
-// История операций
-// ====================
-
-func (y *yourAbilityName) LastOperation() string {
-    y.mutex.RLock()
-    defer y.mutex.RUnlock()
-    return y.lastOperation
-}
-
-func (y *yourAbilityName) LastError() error {
-    y.mutex.RLock()
-    defer y.mutex.RUnlock()
-    return y.lastError
-}
-
-// ====================
-// Приватные методы
-// ====================
-
-func (y *yourAbilityName) validateParam(param string) error {
-    if param == "" {
-        return fmt.Errorf("parameter cannot be empty")
-    }
-
-    if len(param) > 1000 {
-        return fmt.Errorf("parameter too long")
-    }
-
-    return nil
-}
-
-func (y *yourAbilityName) validateConfig(config Config) error {
-    if config.Endpoint == "" {
-        return fmt.Errorf("endpoint is required")
-    }
-
-    if config.Timeout <= 0 {
-        return fmt.Errorf("timeout must be positive")
-    }
-
-    return nil
-}
-
-// ====================
-// Управление соединением (если нужно)
-// ====================
-
-func (y *yourAbilityName) Connect() error {
-    y.mutex.Lock()
-    defer y.mutex.Unlock()
-
-    if y.isConnected {
-        return nil // уже подключены
-    }
-
-    // Создаем клиент
-    client, err := SomeClientConnect(y.config.Endpoint, y.config.Timeout)
-    if err != nil {
-        y.lastError = fmt.Errorf("connection failed: %w", err)
-        y.lastOperation = "connect_failed"
-        return y.lastError
-    }
-
-    y.client = client
-    y.isConnected = true
-    y.lastOperation = "connected"
-    y.lastError = nil
-
-    return nil
-}
-
-func (y *yourAbilityName) Disconnect() error {
-    y.mutex.Lock()
-    defer y.mutex.Unlock()
-
-    if !y.isConnected {
-        return nil
-    }
-
-    if y.client != nil {
-        y.client.Close()
-    }
-
-    y.isConnected = false
-    y.client = nil
-    y.lastOperation = "disconnected"
-
-    return nil
+// Result asks the actor's ability for its current result.
+func Result() verity.Question[string] {
+    return verity.QuestionAbout("the operation result", func(ctx context.Context, actor verity.Actor) (string, error) {
+        if err := ctx.Err(); err != nil {
+            return "", err
+        }
+        a, err := verity.AbilityOf[Ability](actor)
+        if err != nil {
+            return "", fmt.Errorf("your ability: %w", err)
+        }
+        return a.Result(), nil
+    })
 }
 ```
 
-### 3. Activities (activities.go)
+Example test:
 
 ```go
-package your_ability
+func TestAbility(t *testing.T) {
+    test := verity.NewVerityTest(t, verity.Scene{})
+    actor := test.ActorCalled("Operator").WhoCan(yourability.New())
 
-import (
-    "fmt"
-
-    "github.com/verity-bdd/verity-bdd"
-)
-
-// ====================
-// Basic Activities
-// ====================
-
-// DoSomethingActivity - выполнение операции
-type DoSomethingActivity struct {
-    param string
-}
-
-func DoSomething(param string) *DoSomethingActivity {
-    return &DoSomethingActivity{param: param}
-}
-
-func (d *DoSomethingActivity) PerformAs(actor core.Actor) error {
-    ability, err := actor.AbilityTo(&yourAbilityName{})
-    if err != nil {
-        return fmt.Errorf("actor does not have your ability: %w", err)
-    }
-
-    yourAbility := ability.(YourAbilityName)
-    return yourAbility.DoSomething(d.param)
-}
-
-func (d *DoSomethingActivity) Description() string {
-    return fmt.Sprintf("does something with: %s", d.param)
-}
-
-// ====================
-// Complex Activities
-// ====================
-
-// DoSomethingWithConfigActivity - выполнение с конфигурацией
-type DoSomethingWithConfigActivity struct {
-    param  string
-    config Config
-}
-
-func DoSomethingWithConfig(param string, config Config) *DoSomethingWithConfigActivity {
-    return &DoSomethingWithConfigActivity{
-        param:  param,
-        config: config,
-    }
-}
-
-func (d *DoSomethingWithConfigActivity) PerformAs(actor core.Actor) error {
-    ability, err := actor.AbilityTo(&yourAbilityName{})
-    if err != nil {
-        return fmt.Errorf("actor does not have your ability: %w", err)
-    }
-
-    yourAbility := ability.(YourAbilityName)
-
-    // Устанавливаем конфигурацию
-    if err := yourAbility.SetConfig(d.config); err != nil {
-        return fmt.Errorf("failed to set config: %w", err)
-    }
-
-    // Выполняем операцию
-    return yourAbility.DoSomething(d.param)
-}
-
-func (d *DoSomethingWithConfigActivity) Description() string {
-    return fmt.Sprintf("does something with: %s using custom config", d.param)
+    actor.AttemptsTo(
+        yourability.Execute("done"),
+        ensure.That(yourability.Result(), expectations.Equals("done")),
+    )
 }
 ```
 
----
+## Testing skeleton
 
-## 🧪 Шаблон тестов
+Keep a fast unit test for the ability's domain behavior and one actor-level test for each public activity/question path:
 
 ```go
-package your_ability
-
-import (
-    "testing"
-    "time"
-
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
-
-    "github.com/verity-bdd/verity-bdd"
-    "github.com/verity-bdd/verity-bdd/verity_expectations"
-    "github.com/verity-bdd/verity-bdd/verity_expectations"
-)
-
-// ====================
-// Unit Tests
-// ====================
-
-func TestNewYourAbility(t *testing.T) {
-    ability := NewYourAbility()
-
-    assert.NotNil(t, ability)
-    assert.Equal(t, "none", ability.LastOperation())
-    assert.NoError(t, ability.LastError())
+func TestAbilityDomainBehavior(t *testing.T) {
+    ability := yourability.New()
+    require.NoError(t, ability.Execute(context.Background(), "done"))
+    require.Equal(t, "done", ability.Result())
 }
 
-func TestNewYourAbilityWithConfig(t *testing.T) {
-    config := Config{
-        Endpoint: "test://localhost",
-        Timeout:  10 * time.Second,
-    }
-
-    ability := NewYourAbilityWithConfig(config)
-
-    assert.NotNil(t, ability)
-    status := ability.GetStatus()
-    assert.Contains(t, status, "test://localhost")
-}
-
-func TestYourAbility_DoSomething(t *testing.T) {
-    // Arrange
-    ability := NewYourAbility()
-
-    // Mock client setup (если нужно)
-    // setupMockClient(t, ability)
-
-    // Act
-    err := ability.DoSomething("test param")
-
-    // Assert
-    if err != nil {
-        t.Logf("Expected error in unit test: %v", err)
-    }
-
-    assert.Equal(t, "do_something: test param", ability.LastOperation())
-}
-
-// ====================
-// Integration Tests with Actor
-// ====================
-
-func TestYourAbility_WithActor_BasicUsage(t *testing.T) {
+func TestAbilityMissingFromActor(t *testing.T) {
     test := verity.NewVerityTest(t, verity.Scene{})
+    actor := test.ActorCalled("Operator")
 
-    actor := test.ActorCalled("TestUser").WhoCan(
-        NewYourAbility(),
-    )
-
-    err := actor.AttemptsTo(
-        DoSomething("test param"),
-        assertions.That(Status(), expectations.ContainsSubstring("connected")),
-        assertions.That(LastOperation(), expectations.ContainsSubstring("do_something")),
-    )
-
-    // В зависимости от реализации, может быть ошибка или успех
-    if err != nil {
-        t.Logf("Integration test completed with error (expected): %v", err)
-    }
-}
-
-// ====================
-// Error Scenarios
-// ====================
-
-func TestYourAbility_ErrorScenarios(t *testing.T) {
-    test := verity.NewVerityTest(t, verity.Scene{})
-
-    actor := test.ActorCalled("ErrorTester").WhoCan(
-        NewYourAbility(),
-    )
-
-    // Проверка обработки ошибок
-    err := actor.AttemptsTo(
-        DoSomething(""), // пустой параметр - должна быть ошибка
-    )
-
-    assert.Error(t, err)
-    assert.Contains(t, err.Error(), "parameter cannot be empty")
+    _, err := verity.AbilityOf[yourability.Ability](actor)
+    require.Error(t, err)
 }
 ```
 
----
+For networked abilities, inject a narrow client interface and test it with a fake or `httptest.Server`; avoid live services in unit tests.
 
-## 🚀 Быстрый старт
+## Customization checklist
 
-1. **Скопируйте шаблон** в новую папку `verity/abilities/your_ability/`
-2. **Замените `YourAbilityName`** на имя вашей Ability
-3. **Реализуйте основные методы** в `implementation.go`
-4. **Создайте нужные Activities** и `Questions`
-5. **Напишите тесты** following by template
-6. **Обновите импорты** и export нужные функции
+- [ ] Rename the package, contract, constructors, descriptions, and errors for the domain.
+- [ ] Replace `Execute` and `Result` with focused operations and questions.
+- [ ] Add configuration only when callers need it; validate it at construction time.
+- [ ] Add synchronization or resource cleanup when the client or stored state requires it.
+- [ ] Cover success, missing ability, cancellation, and domain failures.
+- [ ] Keep public examples compilable and use the current callback signatures.
 
-## 📝 Что адаптировать
+Checklist:
 
-- `YourAbilityName` → реальное имя вашей Ability
-- `SomeClient` → ваш тип клиента для работы с внешней системой
-- `DoSomething/GetSomething` → реальные методы вашей Ability
-- `Config` → актуальные параметры конфигурации
-- Тайминги, ошибки и логику → под ваши требования
-
----
-
-Этот шаблон обеспечивает:
-- ✅ Thread safety с mutex
-- ✅ Proper error handling с контекстом
-- ✅ Builder patterns для сложных операций
-- ✅ Comprehensive test coverage
-- ✅ Flexible configuration
-- ✅ Clean separation of concerns
-- ✅ Following Go best practices
+- Activities implement `PerformAs(context.Context, verity.Actor) error`, `Description() string`, and `FailureMode() verity.FailureMode`, or are created with `verity.Do`.
+- Questions implement `AnsweredBy(context.Context, verity.Actor) (T, error)` and `Description() string`, or are created with `verity.QuestionAbout`.
+- Retrieve the stored contract with `verity.AbilityOf[Ability](actor)`, not a pointer to that interface.
+- Do not assign the result of `actor.AttemptsTo`; it reports failures through the test context and returns no value.
+- Do not call `WithFailureMode` on `verity.Interaction`; that method does not exist.

--- a/internal/abilities/api/questions.go
+++ b/internal/abilities/api/questions.go
@@ -147,7 +147,7 @@ func (rbaj ResponseBodyAsJSON[T]) Description() string {
 	return "the last response body as JSON"
 }
 
-// JSONPath represents a JSON path query on the response body
+// JSONPath represents an untyped, dot-separated JSON path query.
 type JSONPath struct {
 	path string
 }
@@ -157,7 +157,8 @@ func NewJSONPath(path string) JSONPath {
 	return JSONPath{path: path}
 }
 
-// AnsweredBy returns the value at the specified JSON path
+// AnsweredBy returns a decoded JSON value. Objects, arrays, numbers, strings,
+// booleans, and null use encoding/json's ordinary any representations.
 func (jp JSONPath) AnsweredBy(ctx context.Context, actor core.Actor) (any, error) {
 	ability, err := actor.AbilityTo(&callAnAPI{})
 	if err != nil {
@@ -235,10 +236,10 @@ func (jp JSONPath) extractValue(data any, path []string) (any, error) {
 	}
 }
 
-// ResponseTime returns the response time of the last request
+// ResponseTime is a placeholder for response timing, which is not implemented.
 type ResponseTime struct{}
 
-// AnsweredBy returns the response time (currently returns 0 as timing needs to be implemented in interactions)
+// AnsweredBy returns 0 because request timing is not implemented.
 func (rt ResponseTime) AnsweredBy(ctx context.Context, actor core.Actor) (int64, error) {
 	// This would need timing implementation in interactions
 	return 0, nil

--- a/internal/answerable/answerable.go
+++ b/internal/answerable/answerable.go
@@ -5,7 +5,7 @@
 //	// Static values
 //	ensure.That(answerable.ValueOf(4), expectations.Equals(4))
 //	ensure.That(answerable.ValueOf("hello"), expectations.ContainsSubstring("ell"))
-//	ensure.That(answerable.ValueOf(user), expectations.HasField("Name", "John"))
+//	ensure.That(answerable.ValueOf(user), expectations.Equals(user))
 //
 // For dynamic calculations backed by a function, use verity.QuestionAbout instead.
 //
@@ -22,7 +22,7 @@
 //
 //	// Complex types
 //	user := User{Name: "John", Age: 30}
-//	ensure.That(answerable.ValueOf(user), expectations.HasField("Name", "John"))
+//	ensure.That(answerable.ValueOf(user), expectations.Equals(user))
 //
 //	// Error values (errors are treated as values, not as failures)
 //	err := fmt.Errorf("something went wrong")

--- a/internal/core/activity.go
+++ b/internal/core/activity.go
@@ -35,8 +35,16 @@ func performActivity(ctx context.Context, actor Actor, activity Activity) error 
 //
 //	// Create a simple interaction
 //	sendRequest := core.Do("sends GET request", func(ctx context.Context, actor core.Actor) error {
-//		api := actor.AbilityTo(&api.CallAnAPI{}).(api.CallAnAPI)
-//		return api.SendGetRequest("/users")
+//		ability, err := actor.AbilityTo(api.Using(nil))
+//		if err != nil {
+//			return fmt.Errorf("actor needs API ability: %w", err)
+//		}
+//		request, err := http.NewRequestWithContext(ctx, http.MethodGet, "/users", nil)
+//		if err != nil {
+//			return fmt.Errorf("create GET request: %w", err)
+//		}
+//		_, err = ability.(api.CallAnAPI).SendRequest(request, ctx)
+//		return err
 //	})
 //
 //	// Create a composed task
@@ -46,18 +54,14 @@ func performActivity(ctx context.Context, actor Actor, activity Activity) error 
 //		core.Do("verifies user creation", verifyUser),
 //	)
 //
-//	// Execute activities
-//	err := actor.AttemptsTo(sendRequest, createUser)
+//	// Execute activities; failures are reported through the test context.
+//	actor.AttemptsTo(sendRequest, createUser)
 //
 // Error Handling:
 //
-//	All implementations use FailFast mode by default, meaning execution
-//	stops on the first error. Custom failure modes can be set using
-//	WithFailureMode() on activities that support it.
-//
-//	// Non-critical activity that continues on error
-//	cleanup := core.Do("cleans up test data", cleanupData)
-//	// Note: WithFailureMode would need to be implemented on core.Do
+//	Built-in tasks and interactions use FailFast. The Interaction returned by
+//	Do has no WithFailureMode method; custom Activity implementations can return
+//	a different FailureMode.
 
 // task implements the Task interface for composed activities.
 // Tasks represent high-level business operations that consist of multiple
@@ -176,14 +180,11 @@ func (t *task) FailureMode() FailureMode {
 //
 // Task Execution:
 //
-//	err := actor.AttemptsTo(
+//	actor.AttemptsTo(
 //		registerUser,
 //		placeOrder,
 //		migrateData,
 //	)
-//	if err != nil {
-//		return fmt.Errorf("test workflow failed: %w", err)
-//	}
 //
 // Best Practices:
 //
@@ -227,11 +228,16 @@ type interaction struct {
 //
 //	// Simple API call interaction
 //	sendGetRequest := core.Do("sends GET request to /users", func(ctx context.Context, actor core.Actor) error {
-//		api, err := actor.AbilityTo(&api.CallAnAPI{})
+//		ability, err := actor.AbilityTo(api.Using(nil))
 //		if err != nil {
 //			return fmt.Errorf("actor needs API ability: %w", err)
 //		}
-//		return api.(api.CallAnAPI).SendGetRequest("/users")
+//		request, err := http.NewRequestWithContext(ctx, http.MethodGet, "/users", nil)
+//		if err != nil {
+//			return fmt.Errorf("create GET request: %w", err)
+//		}
+//		_, err = ability.(api.CallAnAPI).SendRequest(request, ctx)
+//		return err
 //	})
 //
 //	// Database query interaction
@@ -263,7 +269,7 @@ type interaction struct {
 //
 //	// System status check interaction
 //	checkHealth := core.Do("checks system health", func(ctx context.Context, actor core.Actor) error {
-//		health := actor.AbilityTo(&monitoring.HealthAbility{})
+//		health, err := actor.AbilityTo(&monitoring.HealthAbility{})
 //		if err != nil {
 //			return fmt.Errorf("actor needs health check ability: %w", err)
 //		}

--- a/internal/core/failure_mode.go
+++ b/internal/core/failure_mode.go
@@ -1,202 +1,29 @@
 package core
 
-// This file defines failure handling modes for activities in Verity-BDD.
-// Failure modes determine how the test execution should proceed when
-// activities encounter errors during execution.
-//
-// Failure Modes:
-//
-//	FailFast          - Stop execution immediately on first error (default)
-//	ErrorButContinue  - Log error but continue with remaining activities
-//	Ignore            - Completely ignore failures and continue
-//
-// Usage Examples:
-//
-//	// Default behavior (FailFast)
-//	actor.AttemptsTo(
-//		core.Do("critical setup", setupSystem),
-//		core.Do("main operation", mainOperation),     // Won't execute if setup fails
-//		core.Do("cleanup", cleanup),                  // Won't execute if above fails
-//	)
-//
-//	// Non-critical operations
-//	actor.AttemptsTo(
-//		core.Do("main operation", mainOperation),
-//		core.Do("log metrics", logMetrics).WithFailureMode(core.NonCritical()),
-//		core.Do("send notification", sendNotification).WithFailureMode(core.NonCritical()),
-//		core.Do("cleanup", cleanup),                   // Always executes
-//	)
-//
-//	// Optional operations
-//	actor.AttemptsTo(
-//		core.Do("main operation", mainOperation),
-//		core.Do("optional cleanup", cleanup).WithFailureMode(core.Optional()),
-//		core.Do("final verification", verification),    // Always executes
-//	)
-//
-// Choosing the Right Mode:
-//
-//	- Use FailFast for critical operations where failure invalidates the test
-//	- Use ErrorButContinue for non-critical operations where failure is notable
-//	- Use Ignore for truly optional operations where failure is expected/acceptable
-//
-
-// FailureMode defines how activities should handle failures.
-// This enum determines whether test execution continues or stops
-// when an activity encounters an error.
-//
-// Default Behavior:
-//
-//	All activities use FailFast mode unless explicitly overridden.
+// FailureMode defines how an Activity implementation asks the actor pipeline to
+// handle an error. Built-in tasks and interactions return FailFast. The
+// Interaction returned by Do has no WithFailureMode method; use a custom
+// Activity implementation to select another mode.
 type FailureMode int
 
 const (
-	// FailFast stops execution immediately when an activity fails.
-	// This is the default and most commonly used failure mode.
-	//
-	// Use Cases:
-	//	- Critical setup operations
-	//	- Main test scenarios
-	//	- Dependencies required for subsequent steps
-	//	- Validation steps that invalidate the test if failed
-	//
-	// Example:
-	//
-	//	actor.AttemptsTo(
-	//		core.Do("establishes database connection", connectToDB), // Critical
-	//		core.Do("creates test data", createTestData),               // Won't run if above fails
-	//		core.Do("runs main test", mainTest),                       // Won't run if above fails
-	//	)
-	//
-	// Behavior:
-	//	- Stops execution immediately on error
-	//	- Returns the first error encountered
-	//	- Subsequent activities are not executed
+	// FailFast stops execution after the activity fails. Built-in activities use
+	// this mode.
 	FailFast FailureMode = iota
 
-	// ErrorButContinue logs the error but continues with remaining activities.
-	// Use this for non-critical operations where you want to know about
-	// failures but don't want them to stop the entire test.
-	//
-	// Use Cases:
-	//	- Monitoring and metrics collection
-	//	- Non-essential notifications
-	//	- Cache operations
-	//	- Audit logging
-	//	- Performance measurements
-	//
-	// Example:
-	//
-	//	actor.AttemptsTo(
-	//		core.Do("executes main business logic", businessLogic),
-	//		core.Do("collects performance metrics", collectMetrics).WithFailureMode(core.NonCritical()),
-	//		core.Do("sends usage statistics", sendStats).WithFailureMode(core.NonCritical()),
-	//		core.Do("verifies result", verifyResult), // Always runs
-	//	)
-	//
-	// Behavior:
-	//	- Logs the error but continues execution
-	//	- Does not return the error unless all activities fail
-	//	- Later activities continue to execute
+	// ErrorButContinue marks the test failed and allows later activities to run.
 	ErrorButContinue
 
-	// Ignore completely ignores the failure and continues.
-	// Use this for truly optional operations where failure is acceptable
-	// or expected in certain scenarios.
-	//
-	// Use Cases:
-	//	- Optional cleanup operations
-	//	- Best-effort notifications
-	//	- Resource cleanup where failure doesn't matter
-	//	- Precondition checks that may legitimately fail
-	//	- Debugging or diagnostic operations
-	//
-	// Example:
-	//
-	//	actor.AttemptsTo(
-	//		core.Do("executes main test", mainTest),
-	//		core.Do("cleans up temporary files", cleanupTempFiles).WithFailureMode(core.Optional()),
-	//		core.Do("attempts to send debug info", sendDebugInfo).WithFailureMode(core.Optional()),
-	//		core.Do("final verification", finalVerification), // Always runs
-	//	)
-	//
-	// Behavior:
-	//	- Completely ignores any errors
-	//	- Never returns errors from this activity
-	//	- Execution continues regardless of success or failure
+	// Ignore logs the error without failing the test and allows later activities to run.
 	Ignore
 )
 
-// Critical returns a failure mode that stops execution on failure.
-// This is a semantic function that returns FailFast mode.
-// Use this when you want to explicitly indicate critical operations.
-//
-// Returns:
-//   - FailureMode: Always returns FailFast
-//
-// Usage:
-//
-//	// Explicit critical operation
-//	actor.AttemptsTo(
-//		core.Do("establishes database connection", connectDB).WithFailureMode(core.Critical()),
-//		core.Do("creates user account", createUser),
-//	)
-//
-//	// Equivalent to default behavior
-//	actor.AttemptsTo(
-//		core.Do("establishes database connection", connectDB), // Already critical by default
-//		core.Do("creates user account", createUser),
-//	)
-//
-// When to Use:
-//   - For clarity in complex test scenarios
-//   - When explicitly documenting critical dependencies
-//   - In reusable test components to ensure critical behavior
+// Critical returns FailFast for use by a custom Activity's FailureMode method.
 func Critical() FailureMode { return FailFast }
 
-// NonCritical returns a failure mode that logs errors but continues.
-// This is a semantic function that returns ErrorButContinue mode.
-// Use this for operations that should be noted but not stop execution.
-//
-// Returns:
-//   - FailureMode: Always returns ErrorButContinue
-//
-// Usage:
-//
-//	actor.AttemptsTo(
-//		core.Do("main business operation", businessLogic),
-//		core.Do("collects usage metrics", collectMetrics).WithFailureMode(core.NonCritical()),
-//		core.Do("sends user notification", sendNotification).WithFailureMode(core.NonCritical()),
-//		core.Do("verifies result", verifyResult),
-//	)
-//
-// When to Use:
-//   - Monitoring and telemetry operations
-//   - Non-essential user communications
-//   - Performance measurements
-//   - Audit and logging activities
+// NonCritical returns ErrorButContinue for use by a custom Activity's
+// FailureMode method.
 func NonCritical() FailureMode { return ErrorButContinue }
 
-// Optional returns a failure mode that ignores errors completely.
-// This is a semantic function that returns Ignore mode.
-// Use this for operations where failure is acceptable or expected.
-//
-// Returns:
-//   - FailureMode: Always returns Ignore
-//
-// Usage:
-//
-//	actor.AttemptsTo(
-//		core.Do("main test execution", mainTest),
-//		core.Do("attempts to cleanup resources", cleanup).WithFailureMode(core.Optional()),
-//		core.Do("tries to send debug report", sendDebugReport).WithFailureMode(core.Optional()),
-//		core.Do("final assertion", finalAssertion),
-//	)
-//
-// When to Use:
-//   - Optional cleanup operations
-//   - Best-effort notifications
-//   - Resource cleanup where failure is acceptable
-//   - Precondition checks that may legitimately fail
-//   - Debug or diagnostic operations
+// Optional returns Ignore for use by a custom Activity's FailureMode method.
 func Optional() FailureMode { return Ignore }

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -36,9 +36,12 @@
 //	)
 //
 //	// Ask questions about system state
-//	userCount := core.QuestionAbout("user count", func(_ context.Context, actor core.Actor) (int, error) {
-//		db := actor.AbilityTo(&database.DatabaseAbility{}).(database.DatabaseAbility)
-//		return db.QueryRow("SELECT COUNT(*) FROM users").Int()
+//	userCount := core.QuestionAbout[any]("user count", func(_ context.Context, actor core.Actor) (any, error) {
+//		ability, err := actor.AbilityTo(&database.DatabaseAbility{})
+//		if err != nil {
+//			return 0, err
+//		}
+//		return ability.(database.DatabaseAbility).QueryRow("SELECT COUNT(*) FROM users").Int()
 //	})
 //
 //	count, err := userCount.AnsweredBy(ctx, actor)
@@ -53,7 +56,7 @@
 //
 //	// Interaction example
 //	sendRequest := core.Do("sends POST request", func(ctx context.Context, actor core.Actor) error {
-//		return api.SendPostRequest("/users", userData).PerformAs(ctx, actor)
+//		return api.SendPostRequest("/users").WithBody(userData).PerformAs(ctx, actor)
 //	})
 //
 //	// Task example
@@ -69,42 +72,32 @@
 //
 //	// Type-safe question with generic parameter
 //	userName := core.QuestionAbout("current user name", func(ctx context.Context, actor core.Actor) (string, error) {
-//		session := actor.AbilityTo(&auth.SessionAbility{}).(auth.SessionAbility)
-//		return session.GetCurrentUser().Name, nil
+//		ability, err := actor.AbilityTo(&auth.SessionAbility{})
+//		if err != nil {
+//			return "", err
+//		}
+//		return ability.(auth.SessionAbility).GetCurrentUser().Name, nil
 //	})
 //
 //	// Complex type question
 //	userProfile := core.QuestionAbout("user profile", func(ctx context.Context, actor core.Actor) (*UserProfile, error) {
-//		db := actor.AbilityTo(&database.DatabaseAbility{}).(database.DatabaseAbility)
-//		return db.GetUserProfile(actor.Name())
+//		ability, err := actor.AbilityTo(&database.DatabaseAbility{})
+//		if err != nil {
+//			return nil, err
+//		}
+//		return ability.(database.DatabaseAbility).GetUserProfile(actor.Name())
 //	})
 //
 //	// Questions can be used directly or with expectations
 //	actor.AttemptsTo(
 //		ensure.That(userName, expectations.ContainsSubstring("John")),
-//		ensure.That(userProfile, expectations.HasField("Email", expectations.IsNotEmpty())),
 //	)
 //
 // Failure Modes:
 //
-//	Activities can specify how failures should be handled:
-//
-//	// FailFast (default) - stops execution on first failure
-//	actor.AttemptsTo(
-//		core.Do("critical operation", criticalStep), // stops if this fails
-//		core.Do("cleanup operation", cleanupStep),    // won't execute if above fails
-//	)
-//
-//	// ErrorButContinue - logs error but continues execution
-//	actor.AttemptsTo(
-//		core.Do("non-critical step", nonCriticalStep).WithFailureMode(core.NonCritical()),
-//		core.Do("another step", anotherStep), // executes even if above fails
-//	)
-//
-//	// Ignore - completely ignores failures
-//	actor.AttemptsTo(
-//		core.Do("optional cleanup", optionalCleanup).WithFailureMode(core.Optional()),
-//	)
+//	Built-in tasks and interactions are fail-fast. A custom Activity can return
+//	ErrorButContinue or Ignore from FailureMode. Interactions returned by Do do
+//	not expose a WithFailureMode method.
 //
 // Integration with Other Packages:
 //
@@ -173,7 +166,7 @@ import (
 //	)
 //
 //	// Perform activities
-//	err := actor.AttemptsTo(
+//	actor.AttemptsTo(
 //		core.Do("creates customer order", func(ctx context.Context, a core.Actor) error {
 //			return createOrder(orderData).PerformAs(ctx, a)
 //		}),
@@ -183,13 +176,13 @@ import (
 //	)
 //
 //	// Access abilities directly
-//	apiAbility, err := actor.AbilityTo(&api.CallAnAPI{})
+//	apiAbility, err := actor.AbilityTo(api.Using(nil))
 //	if err != nil {
 //		return fmt.Errorf("actor lacks API ability: %w", err)
 //	}
 //
 //	// Use ability for custom operations
-//	response, err := apiAbility.(api.CallAnAPI).SendRequest(request)
+//	response, err := apiAbility.(api.CallAnAPI).SendRequest(request, request.Context())
 //
 // Thread Safety:
 //
@@ -246,13 +239,13 @@ type Actor interface {
 	// Example:
 	//
 	//	// Get API ability
-	//	apiAbility, err := actor.AbilityTo(&api.CallAnAPI{})
+	//	apiAbility, err := actor.AbilityTo(api.Using(nil))
 	//	if err != nil {
 	//		return fmt.Errorf("actor needs API ability: %w", err)
 	//	}
 	//
 	//	// Use the ability
-	//	response, err := apiAbility.(api.CallAnAPI).SendRequest(request)
+	//	response, err := apiAbility.(api.CallAnAPI).SendRequest(request, request.Context())
 	//
 	// Common pattern for ability access:
 	//
@@ -263,32 +256,19 @@ type Actor interface {
 	//	specificAbility := ability.(TargetType)
 	AbilityTo(ability abilities.Ability) (abilities.Ability, error)
 
-	// AttemptsTo performs one or more activities sequentially.
-	// Stops execution immediately if any activity fails (unless using custom failure modes).
+	// AttemptsTo performs one or more activities sequentially. Activity errors
+	// are handled according to FailureMode and reported through the test context.
+	// AttemptsTo itself returns no value.
 	//
 	// Parameters:
 	//   - activities: One or more activities to perform
 	//
-	// Returns:
-	//   - error: The first error encountered during activity execution
-	//
 	// Example:
 	//
-	//	err := actor.AttemptsTo(
+	//	actor.AttemptsTo(
 	//		core.Do("logs into system", login),
 	//		core.Do("creates user account", createUser),
 	//		core.Do("verifies user creation", verifyUser),
-	//	)
-	//	if err != nil {
-	//		return fmt.Errorf("user creation flow failed: %w", err)
-	//	}
-	//
-	// With custom failure modes:
-	//
-	//	actor.AttemptsTo(
-	//		core.Do("critical step", criticalStep),
-	//		core.Do("optional cleanup", cleanup).WithFailureMode(core.Optional()),
-	//		core.Do("final verification", verification),
 	//	)
 	AttemptsTo(activities ...Activity)
 }
@@ -339,7 +319,7 @@ type Actor interface {
 //	Activities should return descriptive errors with context:
 //
 //	func (a *MyActivity) PerformAs(ctx context.Context, actor core.Actor) error {
-//		ability, err := actor.AbilityTo(&api.CallAnAPI{})
+//		ability, err := actor.AbilityTo(api.Using(nil))
 //		if err != nil {
 //			return fmt.Errorf("actor lacks API ability: %w", err)
 //		}
@@ -370,13 +350,17 @@ type Activity interface {
 	// Example:
 	//
 	//	func (s *SendRequestActivity) PerformAs(ctx context.Context, actor core.Actor) error {
-	//		ability, err := actor.AbilityTo(&api.CallAnAPI{})
+	//		ability, err := actor.AbilityTo(api.Using(nil))
 	//		if err != nil {
 	//			return fmt.Errorf("actor needs API ability: %w", err)
 	//		}
 	//
-	//		api := ability.(api.CallAnAPI)
-	//		return api.SendRequest(s.method, s.path, ctx)
+	//		request, err := http.NewRequestWithContext(ctx, s.method, s.path, nil)
+	//		if err != nil {
+	//			return fmt.Errorf("create request: %w", err)
+	//		}
+	//		_, err = ability.(api.CallAnAPI).SendRequest(request, ctx)
+	//		return err
 	//	}
 	PerformAs(ctx context.Context, actor Actor) error
 
@@ -400,9 +384,8 @@ type Activity interface {
 	// Returns:
 	//   - FailureMode: How to handle failures (FailFast, ErrorButContinue, Ignore)
 	//
-	// Default behavior:
-	//	- Most activities use FailFast (stop on first error)
-	//	- Can be overridden with WithFailureMode() on core.Do activities
+	// Built-in tasks and interactions use FailFast. Custom Activity
+	// implementations can return another mode.
 	//
 	// Example:
 	//
@@ -427,11 +410,16 @@ type Activity interface {
 //
 //	// API call interaction
 //	sendGetRequest := core.Do("sends GET request to /users", func(ctx context.Context, actor core.Actor) error {
-//		ability, err := actor.AbilityTo(&api.CallAnAPI{})
+//		ability, err := actor.AbilityTo(api.Using(nil))
 //		if err != nil {
 //			return fmt.Errorf("actor needs API ability: %w", err)
 //		}
-//		return ability.(api.CallAnAPI).SendGetRequest("/users")
+//		request, err := http.NewRequestWithContext(ctx, http.MethodGet, "/users", nil)
+//		if err != nil {
+//			return fmt.Errorf("create GET request: %w", err)
+//		}
+//		_, err = ability.(api.CallAnAPI).SendRequest(request, ctx)
+//		return err
 //	})
 //
 //	// Database query interaction
@@ -521,7 +509,7 @@ type Interaction interface {
 //	}
 //
 //	func (c *CreateUserTask) PerformAs(ctx context.Context, actor core.Actor) error {
-//		return actor.AttemptsTo(
+//		return core.TaskWhere("creates a user",
 //			core.Do("validates user data", func(ctx context.Context, a core.Actor) error {
 //				return validateUserData(c.userData)
 //			}),
@@ -531,7 +519,7 @@ type Interaction interface {
 //			core.Do("verifies user exists", func(ctx context.Context, a core.Actor) error {
 //				return verifyUserExists(c.userData.Email)
 //			}),
-//		)
+//		).PerformAs(ctx, actor)
 //	}
 //
 //	func (c *CreateUserTask) Description() string {
@@ -562,15 +550,21 @@ type Task interface {
 // Creating Questions:
 //
 //	// Using core.QuestionAbout (convenience factory)
-//	userCount := core.QuestionAbout("user count", func(_ context.Context, actor core.Actor) (int, error) {
-//		db := actor.AbilityTo(&database.DatabaseAbility{}).(database.DatabaseAbility)
-//		return db.QueryRow("SELECT COUNT(*) FROM users").Int()
+//	userCount := core.QuestionAbout[any]("user count", func(_ context.Context, actor core.Actor) (any, error) {
+//		ability, err := actor.AbilityTo(&database.DatabaseAbility{})
+//		if err != nil {
+//			return 0, err
+//		}
+//		return ability.(database.DatabaseAbility).QueryRow("SELECT COUNT(*) FROM users").Int()
 //	})
 //
 //	// Using core.QuestionAbout
 //	userName := core.QuestionAbout("current user name", func(ctx context.Context, actor core.Actor) (string, error) {
-//		session := actor.AbilityTo(&auth.SessionAbility{}).(auth.SessionAbility)
-//		return session.GetCurrentUser().Name, nil
+//		ability, err := actor.AbilityTo(&auth.SessionAbility{})
+//		if err != nil {
+//			return "", err
+//		}
+//		return ability.(auth.SessionAbility).GetCurrentUser().Name, nil
 //	})
 //
 // Using Questions:
@@ -584,7 +578,7 @@ type Task interface {
 //
 //	// With expectations (recommended)
 //	actor.AttemptsTo(
-//		ensure.That(userCount, expectations.GreaterThan(0)),
+//		ensure.That(userCount, expectations.IsGreaterThan(0)),
 //		ensure.That(userName, expectations.ContainsSubstring("admin")),
 //	)
 //
@@ -601,14 +595,24 @@ type Task interface {
 //
 //	// Complex type question
 //	userProfile := core.QuestionAbout("user profile", func(_ context.Context, actor core.Actor) (*UserProfile, error) {
-//		db := actor.AbilityTo(&database.DatabaseAbility{}).(database.DatabaseAbility)
-//		return db.GetUserProfile(actor.Name())
+//		ability, err := actor.AbilityTo(&database.DatabaseAbility{})
+//		if err != nil {
+//			return nil, err
+//		}
+//		return ability.(database.DatabaseAbility).GetUserProfile(actor.Name())
 //	})
 //
 //	// Collection question
-//	activeOrders := core.QuestionAbout("active orders", func(_ context.Context, actor core.Actor) ([]Order, error) {
-//		api := actor.AbilityTo(&api.CallAnAPI{}).(api.CallAnAPI)
-//		response, err := api.Get("/orders?status=active")
+//	activeOrders := core.QuestionAbout("active orders", func(ctx context.Context, actor core.Actor) ([]Order, error) {
+//		ability, err := actor.AbilityTo(api.Using(nil))
+//		if err != nil {
+//			return nil, err
+//		}
+//		request, err := http.NewRequestWithContext(ctx, http.MethodGet, "/orders?status=active", nil)
+//		if err != nil {
+//			return nil, err
+//		}
+//		response, err := ability.(api.CallAnAPI).SendRequest(request, ctx)
 //		if err != nil {
 //			return nil, err
 //		}
@@ -617,8 +621,11 @@ type Task interface {
 //
 //	// Error-state question
 //	lastError := core.QuestionAbout("last system error", func(_ context.Context, actor core.Actor) (*ErrorInfo, error) {
-//		log := actor.AbilityTo(&logging.LogAbility{}).(logging.LogAbility)
-//		return log.GetLastError()
+//		ability, err := actor.AbilityTo(&logging.LogAbility{})
+//		if err != nil {
+//			return nil, err
+//		}
+//		return ability.(logging.LogAbility).GetLastError()
 //	})
 //
 // Question Design Patterns:
@@ -633,20 +640,23 @@ type Task interface {
 //
 //     // State Question
 //     systemStatus := core.QuestionAbout("system status", func(_ context.Context, actor core.Actor) (SystemStatus, error) {
-//     monitor := actor.AbilityTo(&monitoring.Ability{}).(monitoring.Ability)
-//     return monitor.GetCurrentStatus()
+//     ability, err := actor.AbilityTo(&monitoring.Ability{})
+//     if err != nil { return SystemStatus{}, err }
+//     return ability.(monitoring.Ability).GetCurrentStatus()
 //     })
 //
 //     // Calculation Question
 //     averageResponseTime := core.QuestionAbout("average response time", func(_ context.Context, actor core.Actor) (time.Duration, error) {
-//     metrics := actor.AbilityTo(&metrics.Ability{}).(metrics.Ability)
-//     return metrics.CalculateAverageResponseTime(time.Hour)
+//     ability, err := actor.AbilityTo(&metrics.Ability{})
+//     if err != nil { return 0, err }
+//     return ability.(metrics.Ability).CalculateAverageResponseTime(time.Hour)
 //     })
 //
 //     // Validation Question
 //     hasValidLicense := core.QuestionAbout("has valid license", func(_ context.Context, actor core.Actor) (bool, error) {
-//     license := actor.AbilityTo(&license.Ability{}).(license.Ability)
-//     return license.IsValid()
+//     ability, err := actor.AbilityTo(&license.Ability{})
+//     if err != nil { return false, err }
+//     return ability.(license.Ability).IsValid()
 //     })
 //
 // Best Practices:
@@ -687,7 +697,7 @@ type Question[T any] interface {
 	//			return 0, fmt.Errorf("actor needs database ability: %w", err)
 	//		}
 	//
-	//		return db.QueryRowContext(ctx, "SELECT COUNT(*) FROM users").Int()
+	//		return db.(database.DatabaseAbility).QueryRowContext(ctx, "SELECT COUNT(*) FROM users").Int()
 	//	}
 	//
 	// Usage:

--- a/internal/core/question.go
+++ b/internal/core/question.go
@@ -20,14 +20,20 @@ import (
 //
 //	// Create a question using QuestionAbout
 //	userCount := core.QuestionAbout[int]("number of users", func(_ context.Context, actor core.Actor) (int, error) {
-//		db := actor.AbilityTo(&database.DatabaseAbility{}).(database.DatabaseAbility)
-//		return db.QueryRow("SELECT COUNT(*) FROM users").Int()
+//		ability, err := actor.AbilityTo(&database.DatabaseAbility{})
+//		if err != nil {
+//			return 0, err
+//		}
+//		return ability.(database.DatabaseAbility).QueryRow("SELECT COUNT(*) FROM users").Int()
 //	})
 //
 //	// Another question using QuestionAbout
 //	userName := core.QuestionAbout("current user name", func(_ context.Context, actor core.Actor) (string, error) {
-//		session := actor.AbilityTo(&auth.SessionAbility{}).(auth.SessionAbility)
-//		return session.GetCurrentUser().Name
+//		ability, err := actor.AbilityTo(&auth.SessionAbility{})
+//		if err != nil {
+//			return "", err
+//		}
+//		return ability.(auth.SessionAbility).GetCurrentUser().Name, nil
 //	})
 //
 // Type Safety:
@@ -46,9 +52,8 @@ import (
 // Using Questions with Expectations:
 //
 //	actor.AttemptsTo(
-//		ensure.That(userCount, expectations.GreaterThan(0)),
+//		ensure.That(userCount, expectations.Equals(count)),
 //		ensure.That(userName, expectations.ContainsSubstring("admin")),
-//		ensure.That(userProfile, expectations.HasField("Email", expectations.IsNotEmpty())),
 //	)
 //
 
@@ -132,7 +137,7 @@ func (q *question[T]) AnsweredBy(ctx context.Context, actor Actor) (T, error) {
 //
 //	// With expectations
 //	actor.AttemptsTo(
-//		ensure.That(isHealthy, expectations.IsTrue()),
+//		ensure.That(isHealthy, expectations.Equals(true)),
 //	)
 func QuestionAbout[T any](description string, ask func(ctx context.Context, actor Actor) (T, error)) Question[T] {
 	if ask == nil {

--- a/internal/testing/actor.go
+++ b/internal/testing/actor.go
@@ -77,33 +77,25 @@ func (ta *testActor) AbilityTo(abilityType abilities.Ability) (abilities.Ability
 	return nil, fmt.Errorf("actor '%s' can't %s. Did you give them the ability?", ta.name, abName)
 }
 
-// AttemptsTo executes activities and automatically handles any errors through TestContext.
-// Unlike the legacy API, no manual error checking is required - failures automatically
-// fail the test with descriptive error messages.
+// AttemptsTo executes activities and automatically handles errors through TestContext.
+// No manual error checking is required: failures are recorded on TestContext, and
+// FailFast activities also call FailNow.
 //
 // Example:
 //
-//	// TestContext API - automatic error handling
 //	actor.AttemptsTo(
 //		api.SendGetRequest("/users"),
 //		ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
 //	)
-//
-//	// Legacy API comparison
-//	err := legacyActor.AttemptsTo(
-//		api.SendGetRequest("/users"),
-//		ensure.That(api.LastResponseStatus{}, expectations.Equals(200)),
-//	)
-//	require.NoError(t, err) // Manual error handling required
 //
 // Parameters:
 //
 //	activities - List of activities to execute in order
 //
 // This method automatically handles different failure modes:
-//   - FailFast: Stops test execution immediately on error
-//   - ErrorButContinue: Logs error but continues with remaining activities
-//   - Ignore: Silently ignores the error and continues
+//   - FailFast: Marks the test failed and stops execution immediately
+//   - ErrorButContinue: Marks the test failed via Errorf and continues
+//   - Ignore: Logs the error via Logf and continues without failing the test
 func (ta *testActor) AttemptsTo(activities ...core.Activity) {
 	for _, activity := range activities {
 		err := ta.PerformActivity(ta.ctx, activity)

--- a/internal/testing/context.go
+++ b/internal/testing/context.go
@@ -1,12 +1,12 @@
 // Package testing provides the TestContext API for simplified testing in Go.
 //
-// The TestContext API eliminates the need for manual error handling in tests by
-// automatically managing test failures through the testing.TB interface.
+// The TestContext API reports activity errors according to each activity's
+// FailureMode through the testing.TB-like interface.
 //
 // Key Features:
 //
-//   - Automatic error handling through TestContext
-//   - Actor lifecycle management with defer.Shutdown()
+//   - Failure-mode-aware error handling through TestContext
+//   - Automatic actor cleanup through TestContext.Cleanup
 //   - Integrated reporting capabilities
 //   - Support for multiple actors in single test
 //   - Thread-safe actor management
@@ -31,24 +31,21 @@
 //	admin := test.ActorCalled("Admin").WhoCan(api.CallAnApiAt(apiURL))
 //	user := test.ActorCalled("User").WhoCan(api.CallAnApiAt(apiURL))
 //
-//	admin.AttemptsTo(api.SendPostRequest("/users", userData))
+//	admin.AttemptsTo(api.SendPostRequest("/users").WithBody(userData))
 //	user.AttemptsTo(api.SendGetRequest("/users/1"))
 //
 // Custom Reporting:
 //
 //	reporter := custom.NewJSONReporter()
-//	test := verity.NewVerityTestWithReporter(t, reporter)
+//	test := verity.NewVerityTestWithReporter(context.Background(), t, reporter)
 //
 // Error Handling:
 //
 //	Unlike the legacy API where errors need to be manually handled:
 //
-//	// Legacy approach
-//	err := actor.AttemptsTo(activity)
-//	require.NoError(t, err)
-//
-//	// TestContext API - automatic error handling
-//	actor.AttemptsTo(activity) // Errors automatically fail the test
+//	// AttemptsTo applies the activity's failure mode and returns no error.
+//	actor.AttemptsTo(activity)
+//	// FailFast: Errorf + FailNow; ErrorButContinue: Errorf; Ignore: Logf only.
 //
 // Thread Safety:
 //
@@ -58,12 +55,11 @@ package testing
 
 //go:generate go run go.uber.org/mock/mockgen@latest -source=context.go -destination=mocks/mock_test_context.go -package=mocks
 
-// TestContext provides a testing.TB wrapper for automatic error handling.
-// This interface enables the TestContext API where test failures are automatically
-// handled without the need for manual error checking.
+// TestContext provides the testing hooks used by actors to handle activity errors.
+// AttemptsTo applies the activity's FailureMode without returning an error.
 //
-// Methods automatically call t.Helper() and t.Fatalf() on errors,
-// eliminating the need for require.NoError() calls in test code.
+// FailFast reports with Errorf and stops with FailNow; ErrorButContinue reports
+// with Errorf and continues; Ignore logs with Logf and does not fail the test.
 type TestContext interface {
 	// Name returns the name of the test
 	Name() string
@@ -112,13 +108,13 @@ type TestContext interface {
 //
 //	actor := test.ActorCalled("ErrorProneUser").WhoCan(api.CallAnApiAt("https://invalid.example.com"))
 //
-//	// This will automatically fail the test with a descriptive error
+//	// SendGetRequest is FailFast, so an error reports with Errorf and calls FailNow.
 //	actor.AttemptsTo(api.SendGetRequest("/endpoint"))
 //
 // Custom Reporters:
 //
 //	reporter := &customReporter{output: os.Stdout}
-//	test := verity.NewVerityTestWithReporter(t, reporter)
+//	test := verity.NewVerityTestWithReporter(context.Background(), t, reporter)
 //
 //	actor := test.ActorCalled("ReportedUser").WhoCan(api.CallAnApiAt(apiURL))
 //	actor.AttemptsTo(api.SendGetRequest("/users"))

--- a/internal/testing/verity_test_manager.go
+++ b/internal/testing/verity_test_manager.go
@@ -38,7 +38,7 @@ type Scene struct {
 //  1. Create test instance with NewVerityTest() or NewVerityTestWithReporter()
 //  2. Create actors using ActorCalled()
 //  3. Execute test activities
-//  4. Call Shutdown() to clean up resources (typically via defer)
+//  4. Registered cleanup calls Shutdown automatically; explicit calls are optional
 //
 // Thread Safety:
 //
@@ -75,9 +75,9 @@ type VerityTest interface {
 
 	// Shutdown cleans up resources and terminally finalizes the test. It is
 	// idempotent; after it returns, ActorCalled panics and Actors returns an empty
-	// snapshot.
-	// This method should be called via defer after creating the test instance.
-	// Failure to call Shutdown() may result in resource leaks.
+	// snapshot. NewVerityTest registers Shutdown with TestContext.Cleanup
+	// automatically. Calling Shutdown explicitly is optional when earlier
+	// finalization is useful.
 	//
 	// Example:
 	//	test := verity.NewVerityTest(t, verity.Scene{})
@@ -115,7 +115,7 @@ type VerityTest interface {
 //
 //	func TestWithCustomReporting(t *testing.T) {
 //		reporter := custom.NewJSONReporter()
-//		test := verity.NewVerityTestWithReporter(t, reporter)
+//		test := verity.NewVerityTestWithReporter(context.Background(), t, reporter)
 //
 //		actor := test.ActorCalled("ReportedUser").WhoCan(api.CallAnApiAt(apiURL))
 //		actor.AttemptsTo(api.SendGetRequest("/health"))

--- a/testing_api.go
+++ b/testing_api.go
@@ -23,7 +23,7 @@ type Scene = internaltesting.Scene
 //  1. Create test instance with NewVerityTest() or NewVerityTestWithReporter()
 //  2. Create actors using ActorCalled()
 //  3. Execute test activities
-//  4. Call Shutdown() to clean up resources (typically via defer)
+//  4. Cleanup calls Shutdown automatically; explicit Shutdown is optional and idempotent
 //
 // Thread Safety:
 //
@@ -31,12 +31,11 @@ type Scene = internaltesting.Scene
 //	create and use actors from the same test instance.
 type VerityTest = internaltesting.VerityTest
 
-// TestContext provides a testing.TB wrapper for automatic error handling.
-// This interface enables the TestContext API where test failures are automatically
-// handled without the need for manual error checking.
+// TestContext provides the testing hooks used to report activity failures.
+// AttemptsTo applies each activity's FailureMode without returning an error.
 //
-// Methods automatically call t.Helper() and t.Fatalf() on errors,
-// eliminating the need for require.NoError() calls in test code.
+// FailFast reports with Errorf and stops with FailNow; ErrorButContinue reports
+// with Errorf and continues; Ignore logs with Logf and does not fail the test.
 type TestContext = internaltesting.TestContext
 
 // NewVerityTest creates a new VerityTest instance.

--- a/verity_abilities/api/api.go
+++ b/verity_abilities/api/api.go
@@ -25,10 +25,13 @@ type LastResponseBody = internalapi.LastResponseBody
 // ResponseHeader is a question that returns a specific header value from the last HTTP response.
 type ResponseHeader = internalapi.ResponseHeader
 
-// JSONPath is a question that returns the value at a specified JSON path in the last HTTP response body.
+// JSONPath returns an untyped decoded JSON value at a dot-separated path.
+// Object values decode as map[string]any, arrays as []any, numbers as float64,
+// and an array wildcard segment can produce []any.
 type JSONPath = internalapi.JSONPath
 
-// ResponseTime is a question that returns the response time of the last HTTP request.
+// ResponseTime is a placeholder question for request timing. Timing is not
+// implemented, so AnsweredBy currently returns 0.
 type ResponseTime = internalapi.ResponseTime
 
 // Using creates a new CallAnAPI ability with the given HTTP client.
@@ -82,7 +85,9 @@ func NewResponseHeader(key string) ResponseHeader {
 	return internalapi.NewResponseHeader(key)
 }
 
-// NewJSONPath creates a new question that extracts the value at the given JSON path from the last HTTP response body.
+// NewJSONPath creates an untyped question for a dot-separated JSON path.
+// Numeric path segments index arrays and "*" maps the remaining path across
+// array elements, omitting elements for which that remaining path errors.
 func NewJSONPath(path string) JSONPath {
 	return internalapi.NewJSONPath(path)
 }
@@ -98,5 +103,6 @@ var LastResponseStatusQ = internalapi.LastResponseStatusQ
 // LastResponseBodyQ is a pre-built question that returns the body of the last HTTP response.
 var LastResponseBodyQ = internalapi.LastResponseBodyQ
 
-// ResponseTimeQ is a pre-built question that returns the response time of the last HTTP request.
+// ResponseTimeQ is the pre-built timing placeholder. It currently returns 0
+// because request timing is not implemented.
 var ResponseTimeQ = internalapi.ResponseTimeQ

--- a/verity_reporting/allure_reporter/allure_reporter.go
+++ b/verity_reporting/allure_reporter/allure_reporter.go
@@ -1,9 +1,15 @@
+// Package allure_reporter provides an Allure 2 result-file reporter.
 package allure_reporter
 
 import internalallure "github.com/verity-bdd/verity-bdd/internal/reporting/allure_reporter"
 
+// AllureReporter writes test results, nested steps, and callback attachments to
+// an Allure results directory. The normal actor pipeline currently provides no
+// step attachments; built-in actor notes can appear as a test-level attachment.
 type AllureReporter = internalallure.AllureReporter
 
+// NewAllureReporterWithDir returns a reporter that writes Allure result and
+// attachment files beneath dir. SetOutput on this reporter is a no-op.
 func NewAllureReporterWithDir(dir string) *AllureReporter {
 	return internalallure.NewAllureReporterWithDir(dir)
 }

--- a/verity_reporting/console_reporter/console_reporter.go
+++ b/verity_reporting/console_reporter/console_reporter.go
@@ -1,9 +1,14 @@
+// Package console_reporter provides the built-in human-readable reporter.
 package console_reporter
 
 import internalconsole "github.com/verity-bdd/verity-bdd/internal/reporting/console_reporter"
 
+// ConsoleReporter writes test start, completed-step, and test finish lines.
+// OnStepStart tracks nesting but does not write a separate progress line.
 type ConsoleReporter = internalconsole.ConsoleReporter
 
+// NewConsoleReporter returns a reporter that writes to os.Stdout by default.
+// Use SetOutput to select another io.Writer.
 func NewConsoleReporter() *ConsoleReporter {
 	return internalconsole.NewConsoleReporter()
 }

--- a/verity_reporting/reporter.go
+++ b/verity_reporting/reporter.go
@@ -1,3 +1,6 @@
+// Package verity_reporting exposes reporter callback contracts and adapters.
+// Its TestResult and Status types are reporter-facing interfaces and are
+// distinct from the root verity package's core TestResult and Status types.
 package verity_reporting
 
 import internalreporting "github.com/verity-bdd/verity-bdd/internal/reporting"
@@ -5,11 +8,13 @@ import internalreporting "github.com/verity-bdd/verity-bdd/internal/reporting"
 // Reporter handles test execution reporting.
 type Reporter = internalreporting.Reporter
 
-// TestResult represents the result of a test or step execution.
+// TestResult represents the result passed to a test or step callback. Duration
+// is measured in seconds. The contract supports attachments, although normal
+// actor execution currently supplies none to step-finish callbacks.
 type TestResult = internalreporting.TestResult
 
 // Attachment represents additional data to include in a report entry.
-// Content should be a serialized payload (for example, JSON).
+// Content contains the payload bytes and ContentType identifies their media type.
 type Attachment = internalreporting.Attachment
 
 // Status represents the status of a test or step.
@@ -35,12 +40,14 @@ func NewTestRunnerAdapter(reporter Reporter) *TestRunnerAdapter {
 	return internalreporting.NewTestRunnerAdapter(reporter)
 }
 
-// NewActivityTracker creates a new activity tracker.
+// NewActivityTracker creates a tracker that emits reporter step callbacks for
+// activity. Call Start before execution and Finish afterward.
 func NewActivityTracker(reporter Reporter, activity string) *ActivityTracker {
 	return internalreporting.NewActivityTracker(reporter, activity)
 }
 
-// NewActivityTrackerWithActor creates a new activity tracker with an actor name.
+// NewActivityTrackerWithActor creates a tracker and replaces a leading
+// "#actor " activity placeholder with actorName in callback descriptions.
 func NewActivityTrackerWithActor(reporter Reporter, activity, actorName string) *ActivityTracker {
 	return internalreporting.NewActivityTrackerWithActor(reporter, activity, actorName)
 }


### PR DESCRIPTION
## Summary
- align README, library Markdown, and GoDoc with the current public API and runtime behavior
- replace obsolete signatures, imports, expectations, failure-mode claims, lifecycle guidance, and reporting examples
- document current JSONPath, response timing, attachment, waiting, notes, and reporting contracts accurately
- reduce duplicated stale tutorials while preserving concise contribution, licensing, custom-ability testing, planning, and template guidance
- add missing public reporting facade comments

## Scope
- documentation and Go comments only
- no runtime behavior or public signature changes
- verified Go delta: 0 non-comment/non-whitespace changes

## Validation
- all complete standalone Markdown examples compile
- intentional generic mismatch fails for the documented type reason
- Markdown fences, GitHub-style anchors, and local links validated
- repository-wide stale API and behavior scans
- `gofmt -s -l .`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run --timeout=5m`
- `go mod tidy -diff`
- `go doc -all` for affected packages
- `git diff --check`

## Review
Independent pre-PR review passed on iteration 4/5 with no blockers.
