### PR TITLE
docs: restore README banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Verity-BDD is a Go implementation of the Screenplay Pattern, focused on acceptance and HTTP API testing. It requires **Go 1.23.4 or later**.
 
+![Verity-BDD](https://raw.githubusercontent.com/nchursin/resources/refs/heads/master/verity-bdd/dark.png)
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary

- restores the Verity-BDD banner link accidentally removed during the README rewrite
- preserves the original image URL and placement before Installation

## Verification

- `git diff --check`
- image URL returns HTTP 200 with `image/png`